### PR TITLE
chore(openclaw): 升级 OpenClaw 至 2026.3.1

### DIFF
--- a/nodeskclaw-artifacts/openclaw-image/Dockerfile
+++ b/nodeskclaw-artifacts/openclaw-image/Dockerfile
@@ -10,8 +10,8 @@ ARG NODE_VERSION=22
 FROM internet-cn-beijing.cr.volces.com/library/node:${NODE_VERSION}-bookworm-slim
 
 # ---------- 构建参数 ----------
-ARG OPENCLAW_VERSION=2026.2.26
-ARG IMAGE_VERSION=v2026.2.26
+ARG OPENCLAW_VERSION=2026.3.1
+ARG IMAGE_VERSION=v2026.3.1
 
 # ---------- 元数据标签 ----------
 LABEL maintainer="Xy718Labs"


### PR DESCRIPTION
## OpenClaw 版本更新

| 项目 | 值 |
|------|-----|
| 当前版本 | `2026.2.26` |
| 最新版本 | `2026.3.1` |
| Release | https://github.com/openclaw/openclaw/releases/tag/v2026.3.1 |

---

**此 PR 由 GitHub Actions 自动创建。**

合并后请在火山云持续交付流水线中触发镜像构建，或本地执行 `build-and-push.sh` 构建并推送新镜像。