### PR TITLE
fix(collaboration): Channel 插件 SSE broadcast 崩溃风险 + depth 始终为 0 绕过深度保护

### DIFF
--- a/nodeskclaw-backend/app/services/collaboration_service.py
+++ b/nodeskclaw-backend/app/services/collaboration_service.py
@@ -54,18 +54,33 @@ async def handle_collaboration_message(
     Channel plugins cannot track session depth, so when depth=0 (the default
     from plugins), we derive the actual chain depth from recent DB messages.
     """
+    # Fast-path guard: if the caller already supplied an excessive depth,
+    # avoid opening a DB session at all.
+    if depth > msg_service.MAX_COLLABORATION_DEPTH:
+        logger.warning(
+            "Collaboration depth exceeded (%d > %d) from instance %s",
+            depth,
+            msg_service.MAX_COLLABORATION_DEPTH,
+            source_instance_id,
+        )
+        return
+
     async with async_session_factory() as db:
         if depth == 0:
             inferred = await _infer_chain_depth(db, workspace_id, source_instance_id)
             if inferred is not None:
                 depth = inferred
 
-        if depth > msg_service.MAX_COLLABORATION_DEPTH:
-            logger.warning(
-                "Collaboration depth exceeded (%d > %d) from instance %s",
-                depth, msg_service.MAX_COLLABORATION_DEPTH, source_instance_id,
-            )
-            return
+            # Re-check after inference in case the derived depth exceeds the limit.
+            if depth > msg_service.MAX_COLLABORATION_DEPTH:
+                logger.warning(
+                    "Collaboration depth exceeded (%d > %d) from instance %s",
+                    depth,
+                    msg_service.MAX_COLLABORATION_DEPTH,
+                    source_instance_id,
+                )
+                return
+
         source_inst = await _get_instance(db, source_instance_id)
         if source_inst is None:
             logger.warning("Source instance not found: %s", source_instance_id)


### PR DESCRIPTION
## Summary
- **Bug 1 (sse-server.ts broadcast 崩溃)**：当前代码中 `sse-server.ts` 不存在，SSE 机制已被 WebSocket tunnel 替代，该 Bug 不适用
- **Bug 2 (depth 始终为 0)**：Channel 插件 `sendText`/`sendMedia` 硬编码 `depth: 0`，完全绕过后端 `MAX_COLLABORATION_DEPTH` 检查。新增 `_infer_chain_depth()` 函数：当 depth=0 时，查询最近 120 秒内发送给该 Agent 的协作消息 depth 并递增，确保深度保护生效

Closes #24

## Test plan
- [x] Agent A 向 Agent B 发送协作消息，Agent B 回复后再次触发 sendText，验证 depth 正确递增
- [x] 协作链深度超过 MAX_COLLABORATION_DEPTH 时，消息被拒绝并记录 warning 日志
- [x] 超过 120 秒无关联消息时，depth 不被错误推导（保持为 0）

Made with [Cursor](https://cursor.com)