### PR TITLE
fix(collaboration): Agent 发给 human 的消息被静默丢弃 + MAX_COLLABORATION_DEPTH 不一致

### DIFF
--- a/nodeskclaw-backend/README.md
+++ b/nodeskclaw-backend/README.md
@@ -291,7 +291,7 @@ MessageEnvelope 遵循 CloudEvents 1.0 规范，扩展字段：
 
 ### delegate/escalate 协议
 
-Agent 响应以 `delegate:<target>` 或 `escalate:<target>` 开头时，自动构建新 envelope 转发给目标 Agent 或 Human。协作深度限制 `MAX_COLLABORATION_DEPTH=5`，超限拒绝。delegation 链通过 `routing.visited` 追踪已访问节点，`causationid`/`correlationid` 追踪因果链。
+Agent 响应以 `delegate:<target>` 或 `escalate:<target>` 开头时，自动构建新 envelope 转发给目标 Agent 或 Human。协作深度限制 `MAX_COLLABORATION_DEPTH=3`，超限拒绝。delegation 链通过 `routing.visited` 追踪已访问节点，`causationid`/`correlationid` 追踪因果链。
 
 ### Channel 降级链
 

--- a/nodeskclaw-backend/app/services/collaboration_service.py
+++ b/nodeskclaw-backend/app/services/collaboration_service.py
@@ -72,6 +72,34 @@ async def handle_collaboration_message(
             target_inst = await _find_agent_by_name_or_id(db, workspace_id, target[6:])
             if target_inst:
                 resolved_target_id = target_inst.id
+        elif target.startswith("human:"):
+            human_name = target[6:]
+            hh = await _find_human_by_display_name(db, workspace_id, human_name)
+            if hh:
+                await msg_service.record_message(
+                    db,
+                    workspace_id=workspace_id,
+                    sender_type="agent",
+                    sender_id=source_instance_id,
+                    sender_name=source_name,
+                    content=text,
+                    message_type="collaboration",
+                    depth=depth,
+                )
+                from app.api.workspaces import broadcast_event
+                broadcast_event(workspace_id, "agent:collaboration", {
+                    "instance_id": source_instance_id,
+                    "agent_name": source_name,
+                    "target": target,
+                    "content": text,
+                })
+                await _route_to_human(
+                    db, workspace_id, source_instance_id, source_name, hh, text,
+                )
+                await db.commit()
+                return
+            else:
+                logger.warning("Human target not found: %s in workspace %s", human_name, workspace_id)
 
         await msg_service.record_message(
             db,

--- a/nodeskclaw-backend/app/services/tunnel/adapter.py
+++ b/nodeskclaw-backend/app/services/tunnel/adapter.py
@@ -21,8 +21,9 @@ from app.services.tunnel.protocol import TunnelMessage, TunnelMessageType
 
 logger = logging.getLogger(__name__)
 
+from app.services.workspace_message_service import MAX_COLLABORATION_DEPTH
+
 NO_REPLY_BUFFER_SIZE = 30
-MAX_COLLABORATION_DEPTH = 5
 AUTH_TIMEOUT_S = 10
 PING_INTERVAL_S = 30
 PING_TIMEOUT_S = 45


### PR DESCRIPTION
## Summary
- **Bug 1**: `_route_to_human()` 是死代码，`handle_collaboration_message()` 从未调用它。现在新增 `human:` target 分支，匹配到 HumanHex 后调用 `_route_to_human()` 完成飞书/SSE 投递
- **Bug 2**: `MAX_COLLABORATION_DEPTH` 在 `workspace_message_service.py`（值 3）和 `tunnel/adapter.py`（值 5）定义不一致。统一为 `workspace_message_service.py` 中的单一常量，adapter 改为引用

Closes #25

## Test plan
- [x] Agent 使用 `send -t nodeskclaw -to "human:张三"` 发送消息，确认消息通过飞书或 SSE 投递到对应人类用户
- [x] 目标 human 不存在时，后端记录 warning 日志
- [x] 确认 delegation 链深度限制统一生效（SSE 入口和 MessageBus 均使用值 3）

Made with [Cursor](https://cursor.com)