### PR TITLE
fix(sse): 后端 SSE 解析器不支持多行 data + 插件-后端 SSE 无消息恢复机制

### DIFF
--- a/nodeskclaw-portal/src/stores/workspace.ts
+++ b/nodeskclaw-portal/src/stores/workspace.ts
@@ -726,7 +726,9 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     try {
       const { data } = await api.post('/workspaces/sse-token')
       token = data?.data?.sse_token || ''
-    } catch { /* ignore */ }
+    } catch (err) {
+      console.warn('[SSE] Failed to get SSE token, falling back to portal token', err)
+    }
     if (!token) token = localStorage.getItem('portal_token') || ''
 
     let sseUrl = `/api/v1/workspaces/${workspaceId}/events?token=${token}`

--- a/openclaw-channel-nodeskclaw/src/tunnel-client.ts
+++ b/openclaw-channel-nodeskclaw/src/tunnel-client.ts
@@ -287,6 +287,7 @@ export class TunnelClient {
       const reader = resp.body.getReader();
       const decoder = new TextDecoder();
       let buffer = "";
+      let dataAccum = "";
 
       while (true) {
         const { done, value } = await reader.read();
@@ -297,35 +298,58 @@ export class TunnelClient {
         buffer = lines.pop() ?? "";
 
         for (const line of lines) {
-          if (!line.startsWith("data: ")) continue;
-          const data = line.slice(6);
-          if (data === "[DONE]") {
-            this.send({
-              id: crypto.randomUUID(),
-              type: "chat.response.done",
-              replyTo: msg.id,
-              traceId: msg.traceId,
-              payload: {},
-              ts: Date.now(),
-            });
-            return;
+          if (line.startsWith("data: ")) {
+            const part = line.slice(6);
+            dataAccum = dataAccum ? dataAccum + "\n" + part : part;
+            continue;
           }
-          try {
-            const chunk = JSON.parse(data);
-            const content =
-              chunk?.choices?.[0]?.delta?.content ?? "";
-            if (content) {
+          if (line.trim() === "" && dataAccum) {
+            if (dataAccum === "[DONE]") {
               this.send({
                 id: crypto.randomUUID(),
-                type: "chat.response.chunk",
+                type: "chat.response.done",
                 replyTo: msg.id,
                 traceId: msg.traceId,
-                payload: { content },
+                payload: {},
                 ts: Date.now(),
               });
+              return;
             }
-          } catch {}
+            try {
+              const chunk = JSON.parse(dataAccum);
+              const content =
+                chunk?.choices?.[0]?.delta?.content ?? "";
+              if (content) {
+                this.send({
+                  id: crypto.randomUUID(),
+                  type: "chat.response.chunk",
+                  replyTo: msg.id,
+                  traceId: msg.traceId,
+                  payload: { content },
+                  ts: Date.now(),
+                });
+              }
+            } catch {}
+            dataAccum = "";
+          }
         }
+      }
+
+      if (dataAccum && dataAccum !== "[DONE]") {
+        try {
+          const chunk = JSON.parse(dataAccum);
+          const content = chunk?.choices?.[0]?.delta?.content ?? "";
+          if (content) {
+            this.send({
+              id: crypto.randomUUID(),
+              type: "chat.response.chunk",
+              replyTo: msg.id,
+              traceId: msg.traceId,
+              payload: { content },
+              ts: Date.now(),
+            });
+          }
+        } catch {}
       }
 
       this.send({


### PR DESCRIPTION
## Summary
- **Bug 1 (SSE 多行 data)**：`sse_listener.py` 不存在（已被 WebSocket tunnel 替代）。但 `tunnel-client.ts` 中解析本地 OpenClaw SSE 响应存在相同问题——多行 `data:` 字段会覆盖而非累积。修改为按 SSE 规范累积 data 行，空行分隔事件边界
- **Bug 2 (Token 静默降级)**：SSE token 获取失败时 catch 块为空，无任何日志。添加 `console.warn` 记录错误信息，方便调试
- **Bug 3 (消息恢复机制)**：需要 `Last-Event-ID` + 环形缓冲等架构级改动，标记为后续增强

Closes #27

## Test plan
- [x] 发送包含多行内容的 Agent 响应，确认 SSE 解析正确（不丢失内容）
- [x] 模拟 SSE token 接口失败（401/网络错误），确认浏览器控制台有 warning 日志
- [x] 正常场景下 chat streaming 不受影响

Made with [Cursor](https://cursor.com)