### PR TITLE
fix(portal): 修复以 / 开头的文件路径被误判为斜杠命令

### DIFF
--- a/nodeskclaw-portal/src/components/chat/ChatPanel.vue
+++ b/nodeskclaw-portal/src/components/chat/ChatPanel.vue
@@ -336,10 +336,10 @@ async function sendMessage() {
     return
   }
 
-  if (text.startsWith('/')) {
-    const words = text.split(/\s+/)
-    const cmd = words[0].slice(1)
-    const arg = words.slice(1).join(' ').replace(/^@/, '')
+  const slashMatch = text.match(/^\/([a-zA-Z]+)(?:\s|$)/)
+  if (slashMatch) {
+    const cmd = slashMatch[1]
+    const arg = text.slice(slashMatch[0].length).trim().replace(/^@/, '')
     executeSlashCommand(cmd, arg || undefined)
     return
   }


### PR DESCRIPTION
## Summary

- 修复聊天面板中以 `/` 开头的文件路径（如 `/root/nodeskclaw/docs`）被错误识别为斜杠命令，显示「未知命令」的 bug
- 将 `text.startsWith('/')` 改为正则 `/^\/([a-zA-Z]+)(?:\s|$)/`，仅 `/纯字母` 格式才匹配命令

## 根因

`ChatPanel.vue` 的 `sendMessage()` 中使用 `text.startsWith('/')` 判断是否为斜杠命令，但 Linux 文件路径同样以 `/` 开头，导致用户发送包含路径的消息时被拦截。

## 修复方案

改为正则匹配 `/^\/([a-zA-Z]+)(?:\s|$)/`：
- `/clear`、`/restart @name`、`/status` → 匹配为命令
- `/root/nodeskclaw/docs ...` → 不匹配，正常发送为聊天消息

Closes #40

## Test plan

- [x] 发送 `/clear` 确认命令仍正常工作
- [x] 发送 `/restart @AgentName` 确认带参数命令正常
- [x] 发送 `/root/nodeskclaw/docs 把代码移过来` 确认不再被误判为命令
- [x] 发送 `/123` 确认非字母开头不被当命令

Made with [Cursor](https://cursor.com)