### PR TITLE
fix(backend): Gemini provider 补充 api 类型映射 google-generative-ai

### DIFF
--- a/nodeskclaw-backend/app/services/llm_config_service.py
+++ b/nodeskclaw-backend/app/services/llm_config_service.py
@@ -36,7 +36,7 @@ def _strip_jsonc(text: str) -> str:
 PROVIDER_BASE_URLS: dict[str, str] = {
     "openai": "https://api.openai.com/v1",
     "anthropic": "https://api.anthropic.com",
-    "gemini": "https://generativelanguage.googleapis.com/v1",
+    "gemini": "https://generativelanguage.googleapis.com",
     "openrouter": "https://openrouter.ai/api/v1",
     "minimax-openai": "https://api.minimaxi.com/v1",
     "minimax-anthropic": "https://api.minimaxi.com/anthropic",
@@ -45,6 +45,7 @@ PROVIDER_BASE_URLS: dict[str, str] = {
 BUILTIN_PROVIDERS = {"openai", "anthropic", "gemini", "openrouter"}
 
 PROVIDER_API_TYPE: dict[str, str] = {
+    "gemini": "google-generative-ai",
     "minimax-openai": "openai-completions",
     "minimax-anthropic": "anthropic-messages",
 }
@@ -95,9 +96,9 @@ def _build_providers_config(
                 logger.error("LLM_PROXY_URL 未配置，Working Plan 模式无法生成 proxy URL")
                 continue
             api_type = PROVIDER_API_TYPE.get(provider)
-            is_anthropic_style = api_type == "anthropic-messages"
+            skip_v1 = api_type in ("anthropic-messages", "google-generative-ai")
             entry = {
-                "baseUrl": f"{proxy_url}/{provider}" if is_anthropic_style else f"{proxy_url}/{provider}/v1",
+                "baseUrl": f"{proxy_url}/{provider}" if skip_v1 else f"{proxy_url}/{provider}/v1",
                 "apiKey": wp_api_key,
             }
 

--- a/nodeskclaw-backend/app/services/model_catalog_service.py
+++ b/nodeskclaw-backend/app/services/model_catalog_service.py
@@ -30,6 +30,7 @@ PROVIDER_BASE_URLS: dict[str, str] = {
 }
 
 PROVIDER_API_TYPE: dict[str, str] = {
+    "gemini": "google-generative-ai",
     "minimax-openai": "openai-completions",
     "minimax-anthropic": "anthropic-messages",
 }

--- a/nodeskclaw-llm-proxy/app/proxy.py
+++ b/nodeskclaw-llm-proxy/app/proxy.py
@@ -27,7 +27,7 @@ PROVIDER_DEFAULTS: dict[str, dict] = {
     "minimax-anthropic": {"base_url": "https://api.minimaxi.com/anthropic", "auth_type": "bearer"},
 }
 
-_OPENAI_STREAM_PROVIDERS = {"openai", "openrouter", "minimax-openai", "gemini"}
+_OPENAI_STREAM_PROVIDERS = {"openai", "openrouter", "minimax-openai"}
 
 _http_client: httpx.AsyncClient | None = None
 


### PR DESCRIPTION
## Summary

- 修复 Gemini 模型调用返回 404 的问题：`PROVIDER_API_TYPE` 缺少 `"gemini": "google-generative-ai"` 映射，导致 openclaw.json 中 providers.gemini 没有 `"api"` 字段，DeskClaw 默认按 OpenAI 格式调用 Google API
- Gemini `baseUrl` 去掉多余的 `/v1` 后缀（Google AI SDK 内部自行构建含版本的完整路径）
- LLM Proxy 的 `_OPENAI_STREAM_PROVIDERS` 移除 gemini（`stream_options` 是 OpenAI 专有字段，Google API 不支持）

Closes #49

## 变更文件

| 文件 | 改动 |
|------|------|
| `nodeskclaw-backend/app/services/llm_config_service.py` | `PROVIDER_API_TYPE` 新增 gemini 映射；`PROVIDER_BASE_URLS` 去掉 `/v1`；proxy baseUrl 逻辑扩展 |
| `nodeskclaw-backend/app/services/model_catalog_service.py` | `PROVIDER_API_TYPE` 同步新增 gemini 映射 |
| `nodeskclaw-llm-proxy/app/proxy.py` | `_OPENAI_STREAM_PROVIDERS` 移除 gemini |

## Test plan

- [ ] 配置 Gemini API Key，创建实例并发送消息，验证模型正常回复（不再 404）
- [ ] 验证 OpenAI / Anthropic 等其他 provider 不受影响
- [ ] 验证通过 LLM Proxy（org key）和直连（personal key）两种路径均能正常调用 Gemini

Made with [Cursor](https://cursor.com)