### PR TITLE
fix(backend): Gemini provider 配置补充 api 类型字段

### DIFF
--- a/nodeskclaw-backend/app/services/llm_config_service.py
+++ b/nodeskclaw-backend/app/services/llm_config_service.py
@@ -45,6 +45,7 @@ PROVIDER_BASE_URLS: dict[str, str] = {
 BUILTIN_PROVIDERS = {"openai", "anthropic", "gemini", "openrouter"}
 
 PROVIDER_API_TYPE: dict[str, str] = {
+    "gemini": "google-generative-ai",
     "minimax-openai": "openai-completions",
     "minimax-anthropic": "anthropic-messages",
 }


### PR DESCRIPTION
## Summary

- `PROVIDER_API_TYPE` 映射中缺少 `gemini` 条目，导致生成 `openclaw.json` 时 Gemini provider 配置没有 `"api": "google-generative-ai"` 字段，DeskClaw 默认按 OpenAI 格式调用 Google API，返回 404

## 改动

在 `llm_config_service.py` 的 `PROVIDER_API_TYPE` 中添加 `"gemini": "google-generative-ai"`

Closes #49

Made with [Cursor](https://cursor.com)