### PR TITLE
fix(routing): BFS 广播路由按 entity_id 去重，消除重复投递

### DIFF
--- a/nodeskclaw-backend/app/services/corridor_router.py
+++ b/nodeskclaw-backend/app/services/corridor_router.py
@@ -226,6 +226,7 @@ async def get_reachable_endpoints(
 
     endpoints: list[ReachableEndpoint] = []
     hooks_to_fire: list[HookToFire] = []
+    seen_entity_ids: set[str] = set()
     visited: set[tuple[int, int]] = {(from_q, from_r)}
     queue: deque[tuple[tuple[int, int], int]] = deque([((from_q, from_r), 0)])
 
@@ -246,11 +247,14 @@ async def get_reachable_endpoints(
             type_def = NODE_TYPE_REGISTRY.get(node.node_type)
 
             if _should_consume(node.node_type):
-                endpoints.append(ReachableEndpoint(
-                    node.hex_q, node.hex_r, node.node_type,
-                    entity_id,
-                    display_name=node.display_name or "",
-                ))
+                if not (entity_id and entity_id in seen_entity_ids):
+                    if entity_id:
+                        seen_entity_ids.add(entity_id)
+                    endpoints.append(ReachableEndpoint(
+                        node.hex_q, node.hex_r, node.node_type,
+                        entity_id,
+                        display_name=node.display_name or "",
+                    ))
 
             if _should_propagate(node.node_type):
                 if max_hops <= 0 or hops + 1 < max_hops:

--- a/nodeskclaw-backend/app/services/runtime/messaging/middlewares/routing.py
+++ b/nodeskclaw-backend/app/services/runtime/messaging/middlewares/routing.py
@@ -20,6 +20,7 @@ async def _resolve_targets_by_name(
     from sqlalchemy import or_, select
 
     targets: list[DeliveryTarget] = []
+    seen_ids: set[str] = set()
     for name in names:
         stmt = select(NodeCard).where(
             NodeCard.workspace_id == workspace_id,
@@ -31,6 +32,9 @@ async def _resolve_targets_by_name(
         if card is None:
             logger.warning("Routing: target '%s' not found in workspace %s", name, workspace_id)
             continue
+        if card.node_id in seen_ids:
+            continue
+        seen_ids.add(card.node_id)
 
         type_spec = NODE_TYPE_REGISTRY.get(card.node_type)
         transport = type_spec.transport if type_spec else ""
@@ -75,7 +79,11 @@ async def _resolve_broadcast(
                 max_hops=max_hops, visited_ids=visited_set,
             )
             targets_list: list[DeliveryTarget] = []
+            seen_ids: set[str] = set()
             for ep in endpoints:
+                if ep.entity_id in seen_ids:
+                    continue
+                seen_ids.add(ep.entity_id)
                 type_spec = NODE_TYPE_REGISTRY.get(ep.endpoint_type)
                 transport = type_spec.transport if type_spec else ""
                 targets_list.append(DeliveryTarget(
@@ -87,7 +95,11 @@ async def _resolve_broadcast(
 
     addressable = await get_all_addressable_nodes(workspace_id, db)
     targets = []
+    seen_ids: set[str] = set()
     for ep in addressable:
+        if ep.entity_id in seen_ids:
+            continue
+        seen_ids.add(ep.entity_id)
         type_spec = NODE_TYPE_REGISTRY.get(ep.endpoint_type)
         transport = type_spec.transport if type_spec else ""
         targets.append(DeliveryTarget(

--- a/nodeskclaw-backend/app/services/runtime/route_cache.py
+++ b/nodeskclaw-backend/app/services/runtime/route_cache.py
@@ -39,10 +39,17 @@ class RouteTable:
         return self._versions.get(workspace_id, 0)
 
     def put(self, workspace_id: str, targets: list[DeliveryTarget]) -> int:
+        seen: set[str] = set()
+        unique: list[DeliveryTarget] = []
+        for t in targets:
+            if t.node_id not in seen:
+                seen.add(t.node_id)
+                unique.append(t)
+
         version = self._versions.get(workspace_id, 0) + 1
         self._versions[workspace_id] = version
         self._cache[workspace_id] = VersionedRoutes(
-            version=version, targets=targets,
+            version=version, targets=unique,
         )
         return version
 


### PR DESCRIPTION
## Summary

- BFS 广播路由 `get_reachable_endpoints()` 按 hex 坐标去重但不按 `entity_id` 去重，同一逻辑实体出现在多个坐标时会被重复收录，导致 AI 员工被重复投递消息
- 采用三层防御策略在路由管线的不同层级添加 `entity_id` / `node_id` 去重：
  - **层 1**: `corridor_router.py` — BFS 循环内按 `entity_id` 去重（根源修复）
  - **层 2**: `routing.py` — `_resolve_broadcast` 和 `_resolve_targets_by_name` 按 `node_id` 去重
  - **层 3**: `route_cache.py` — `RouteTable.put()` 缓存写入前按 `node_id` 去重

Closes #47

## Test plan

- [ ] 在多路径拓扑中发送广播消息，确认每个 AI 员工只收到一次
- [x] 验证显式 targets 列表包含重复名称时只投递一次
- [ ] 验证 corridor（propagates=True）节点的消息传播不受去重影响
- [ ] 确认日志中不再出现同一 agent 的重复 `Mention skip` 记录


Made with [Cursor](https://cursor.com)