### PR TITLE
fix(backend): tools.allow 工具名列表补全 + 抽取常量

### DIFF
--- a/nodeskclaw-backend/app/services/llm_config_service.py
+++ b/nodeskclaw-backend/app/services/llm_config_service.py
@@ -52,6 +52,15 @@ PROVIDER_API_TYPE: dict[str, str] = {
 
 TRUSTED_PROXY_CIDRS = ["10.0.0.0/8", "100.64.0.0/10", "192.168.0.0/16"]
 
+NODESKCLAW_TOOL_NAMES = (
+    "nodeskclaw_blackboard",
+    "nodeskclaw_topology",
+    "nodeskclaw_performance",
+    "nodeskclaw_proposals",
+    "nodeskclaw_gene_discovery",
+    "nodeskclaw_shared_files",
+)
+
 
 def _k8s_name(instance: Instance) -> str:
     return instance.slug or instance.name
@@ -668,13 +677,7 @@ def _inject_channel_config(
 
     tools_cfg = config.setdefault("tools", {})
     allow = tools_cfg.setdefault("allow", [])
-    for tool_name in (
-        "nodeskclaw_blackboard",
-        "nodeskclaw_topology",
-        "nodeskclaw_performance",
-        "nodeskclaw_proposals",
-        "nodeskclaw_gene_discovery",
-    ):
+    for tool_name in NODESKCLAW_TOOL_NAMES:
         if tool_name not in allow:
             allow.append(tool_name)
 
@@ -740,11 +743,7 @@ async def add_workspace_channel_account(
 
         tools_cfg = existing.setdefault("tools", {})
         allow = tools_cfg.setdefault("allow", [])
-        for tool_name in (
-            "nodeskclaw_blackboard", "nodeskclaw_topology",
-            "nodeskclaw_performance", "nodeskclaw_proposals",
-            "nodeskclaw_gene_discovery",
-        ):
+        for tool_name in NODESKCLAW_TOOL_NAMES:
             if tool_name not in allow:
                 allow.append(tool_name)
 
@@ -1172,11 +1171,7 @@ async def repair_channel_account_urls(db: AsyncSession) -> dict:
 
                 tools_cfg = config.setdefault("tools", {})
                 allow = tools_cfg.setdefault("allow", [])
-                for tool_name in (
-                    "nodeskclaw_blackboard", "nodeskclaw_topology",
-                    "nodeskclaw_performance", "nodeskclaw_proposals",
-                    "nodeskclaw_gene_discovery",
-                ):
+                for tool_name in NODESKCLAW_TOOL_NAMES:
                     if tool_name not in allow:
                         allow.append(tool_name)
                         changed = True


### PR DESCRIPTION
## Summary

- `llm_config_service.py` 中向 `openclaw.json` 注入 `tools.allow` 的工具名列表缺少 `nodeskclaw_shared_files`，导致共享文件工具在实例上不被识别
- 3 处硬编码列表抽取为模块级常量 `NODESKCLAW_TOOL_NAMES`，避免多处维护导致漂移

## Changes

- 新增 `NODESKCLAW_TOOL_NAMES` 常量，包含 6 个工具名
- `_inject_channel_config`、`deploy_nodeskclaw_channel_plugin`、`repair_channel_account_urls` 3 处硬编码列表统一替换为常量引用

## Test plan

- [ ] 部署后查看 AI 员工容器日志，确认 `unknown entries` 告警消失
- [ ] 确认实例 `openclaw.json` 中 `tools.allow` 包含全部 6 个工具名

Closes #60

Made with [Cursor](https://cursor.com)