### PR TITLE
fix(channel-plugin): apiFetch 错误处理 + URL 编码 + performance 工具对齐

### DIFF
--- a/openclaw-channel-nodeskclaw/src/tools.ts
+++ b/openclaw-channel-nodeskclaw/src/tools.ts
@@ -36,15 +36,29 @@ async function apiFetch(
   method = "GET",
   body?: unknown,
 ): Promise<unknown> {
-  const res = await fetch(`${cfg.apiUrl}${path}`, {
-    method,
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${cfg.token}`,
-    },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  return res.json();
+  let res: Response;
+  try {
+    res = await fetch(`${cfg.apiUrl}${path}`, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${cfg.token}`,
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch (err) {
+    return { error: true, message: `Network error: ${(err as Error).message}` };
+  }
+  if (!res.ok) {
+    let detail: string;
+    try { detail = await res.text(); } catch { detail = ""; }
+    return { error: true, status: res.status, message: detail || res.statusText };
+  }
+  try {
+    return await res.json();
+  } catch {
+    return { error: true, message: "Response is not valid JSON" };
+  }
 }
 
 function jsonResult(payload: unknown) {
@@ -314,7 +328,7 @@ function createPerformanceTool(cfg: ToolConfig): AnyAgentTool {
           );
         case "get_team_performance":
           return jsonResult(
-            await apiFetch(cfg, `/workspaces/${ws}/performance/collect`, "POST"),
+            await apiFetch(cfg, `/workspaces/${ws}/performance`),
           );
         case "collect_performance":
           return jsonResult(
@@ -369,7 +383,7 @@ function createProposalsTool(cfg: ToolConfig): AnyAgentTool {
           return jsonResult(
             await apiFetch(
               cfg,
-              `/workspaces/trust-policies/check?workspace_id=${ws}&agent_instance_id=${agentId}&action_type=${p.action_type}`,
+              `/workspaces/trust-policies/check?workspace_id=${ws}&agent_instance_id=${agentId}&action_type=${encodeURIComponent(p.action_type as string)}`,
             ),
           );
         case "list_my_decisions":


### PR DESCRIPTION
## Summary

- `apiFetch` 不检查 `res.ok`，HTTP 4xx/5xx 被静默当成功返回给模型，导致模型无法感知工具调用失败
- `check_trust_policy` 的 `action_type` 未经 `encodeURIComponent` 编码，含特殊字符时破坏请求
- `get_team_performance` 错误调用 `POST .../performance/collect`，与 Python CLI 的 `GET /performance` 语义不一致

## Changes

- **apiFetch**: 外层 try/catch 捕获网络异常；检查 `res.ok`，非 2xx 返回 `{ error, status, message }`；`res.json()` 包裹 try/catch 处理非 JSON 响应
- **check_trust_policy**: `action_type` 参数用 `encodeURIComponent()` 编码
- **get_team_performance**: 改为 `GET /workspaces/${ws}/performance`，与 Python CLI 对齐

## Test plan

- [ ] 模拟后端返回 500，确认模型收到 `{ error: true, status: 500, message: ... }` 而非异常
- [ ] 调用 `check_trust_policy` 传入含特殊字符的 action_type，确认 URL 正确编码
- [ ] 调用 `get_team_performance` 确认走 GET 端点返回团队绩效数据

Closes #61

Made with [Cursor](https://cursor.com)