### PR TITLE
fix(backend): 集群删除时级联清理 workspace_agents、node_cards 和 hex_connections

### DIFF
--- a/nodeskclaw-backend/app/services/cluster_service.py
+++ b/nodeskclaw-backend/app/services/cluster_service.py
@@ -10,9 +10,12 @@ from app.core.exceptions import BadRequestError, ConflictError, NotFoundError
 from app.core.feature_gate import feature_gate
 from app.core.security import decrypt_kubeconfig, encrypt_kubeconfig
 from app.models.cluster import Cluster, ClusterStatus
+from app.models.corridor import HexConnection
 from app.models.deploy_record import DeployRecord
 from app.models.instance import Instance
+from app.models.node_card import NodeCard
 from app.models.user import User
+from app.models.workspace_agent import WorkspaceAgent
 from app.schemas.cluster import ClusterCreate, ClusterInfo, ClusterUpdate, ConnectionTestResult
 
 logger = logging.getLogger(__name__)
@@ -133,6 +136,46 @@ async def delete_cluster(cluster_id: str, db: AsyncSession) -> None:
             .where(DeployRecord.instance_id.in_(instance_ids), DeployRecord.deleted_at.is_(None))
             .values(deleted_at=func.now())
         )
+
+        wa_result = await db.execute(
+            select(WorkspaceAgent.workspace_id, WorkspaceAgent.hex_q, WorkspaceAgent.hex_r)
+            .where(
+                WorkspaceAgent.instance_id.in_(instance_ids),
+                WorkspaceAgent.deleted_at.is_(None),
+            )
+        )
+        wa_positions = wa_result.all()
+
+        await db.execute(
+            update(WorkspaceAgent)
+            .where(WorkspaceAgent.instance_id.in_(instance_ids), WorkspaceAgent.deleted_at.is_(None))
+            .values(deleted_at=func.now())
+        )
+
+        await db.execute(
+            update(NodeCard)
+            .where(NodeCard.node_id.in_(instance_ids), NodeCard.deleted_at.is_(None))
+            .values(deleted_at=func.now())
+        )
+
+        from sqlalchemy import or_, and_
+        if wa_positions:
+            hex_filters = [
+                and_(
+                    HexConnection.workspace_id == ws_id,
+                    or_(
+                        and_(HexConnection.hex_a_q == hq, HexConnection.hex_a_r == hr),
+                        and_(HexConnection.hex_b_q == hq, HexConnection.hex_b_r == hr),
+                    ),
+                )
+                for ws_id, hq, hr in wa_positions
+            ]
+            await db.execute(
+                update(HexConnection)
+                .where(or_(*hex_filters), HexConnection.deleted_at.is_(None))
+                .values(deleted_at=func.now())
+            )
+
         # 级联逻辑删除实例
         await db.execute(
             update(Instance)


### PR DESCRIPTION
## Summary

- `delete_cluster()` 级联软删除实例时，补充清理 `workspace_agents`、`node_cards`、`hex_connections` 三张关联表
- 修复删除集群后重建 Agent 加入工作区时因孤儿 `node_card` 占用六角坐标触发 `UniqueViolationError` 500 的问题

## Root Cause

`cluster_service.delete_cluster()` 只级联软删除了 `instances` 和 `deploy_records`，遗漏了：
- `workspace_agents` — Agent 与工作区的绑定
- `node_cards` — 六角网格卡片（有 `uq_node_card_hex_pos` 唯一约束）
- `hex_connections` — 六角网格连线

## Test Plan

- [x] 集成测试：创建 cluster → instance → workspace_agent/node_card/hex_connection → delete_cluster → 验证 6 张表全部 soft-deleted
- [x] 本地清理孤儿数据后，前端正常添加 Agent 到工作区无 500 错误
- [ ] 在测试环境完整走一遍：创建集群 → 部署实例 → 加入工作区 → 删除集群 → 重新创建并加入

Closes #82

Made with [Cursor](https://cursor.com)