### PR TITLE
fix(security): 审批通道异常时默认拒绝而非放行

### DIFF
--- a/nodeskclaw-backend/app/services/security/plugins/approval_channel.py
+++ b/nodeskclaw-backend/app/services/security/plugins/approval_channel.py
@@ -103,8 +103,8 @@ class ApprovalChannelPlugin:
                 )
                 return result.scalar_one_or_none() is not None
         except Exception:
-            logger.warning("Trust policy check failed, defaulting to allow", exc_info=True)
-            return True
+            logger.error("Trust policy check failed, defaulting to DENY", exc_info=True)
+            return False
 
     async def _request_approval(self, ctx: ExecutionContext, action_type: str) -> str:
         try:
@@ -130,8 +130,8 @@ class ApprovalChannelPlugin:
 
             return await self._poll_decision(record_id)
         except Exception:
-            logger.warning("Approval request failed, defaulting to allow", exc_info=True)
-            return "allow_once"
+            logger.error("Approval request failed, defaulting to DENY", exc_info=True)
+            return "deny"
 
     async def _poll_decision(self, record_id: str) -> str:
         from sqlalchemy import select


### PR DESCRIPTION
## Summary

- `approval_channel.py` 中策略检查和审批请求的 `except Exception` 分支从「故障开放」改为「故障关闭」
- 策略检查失败：`return True`（允许）→ `return False`（拒绝）
- 审批请求失败：`return "allow_once"`（允许一次）→ `return "deny"`（拒绝）
- 日志级别从 `warning` 提升到 `error`

## Test plan

- [ ] 模拟数据库不可用时，工具执行应被拒绝而非放行

Made with [Cursor](https://cursor.com)