### PR TITLE
chore(backend): 清理 service 层未使用的导入和变量

### DIFF
--- a/nodeskclaw-backend/app/services/auth_service.py
+++ b/nodeskclaw-backend/app/services/auth_service.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from typing import Literal
 
 from fastapi import HTTPException, status
-from sqlalchemy import or_, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 

--- a/nodeskclaw-backend/app/services/channel_config_service.py
+++ b/nodeskclaw-backend/app/services/channel_config_service.py
@@ -9,11 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import AppException, BadRequestError
 from app.models.instance import Instance
-from app.services.nfs_mount import RemoteFS, remote_fs
+from app.services.nfs_mount import remote_fs
 from app.services.runtime.config_adapter import get_config_adapter
 from app.services.unified_channel_schema import (
     UNIFIED_CHANNEL_REGISTRY,
-    get_channel_schema,
     get_legacy_channel_schemas,
 )
 

--- a/nodeskclaw-backend/app/services/collaboration_service.py
+++ b/nodeskclaw-backend/app/services/collaboration_service.py
@@ -1,7 +1,6 @@
 """Collaboration message handling — shared by tunnel and (legacy) webhook."""
 
 import asyncio
-import json
 import logging
 from typing import Coroutine
 

--- a/nodeskclaw-backend/app/services/corridor_router.py
+++ b/nodeskclaw-backend/app/services/corridor_router.py
@@ -20,7 +20,6 @@ from app.models.corridor import CorridorHex, HexConnection, HumanHex, ordered_pa
 from app.models.instance import Instance
 from app.models.node_card import NodeCard
 from app.models.workspace_agent import WorkspaceAgent
-from app.models.workspace_member import WorkspaceMember
 from app.models.workspace_message import WorkspaceMessage
 from app.services.runtime.registries.node_type_registry import NODE_TYPE_REGISTRY
 

--- a/nodeskclaw-backend/app/services/gene_service.py
+++ b/nodeskclaw-backend/app/services/gene_service.py
@@ -7,8 +7,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Coroutine
 
-import httpx
-from sqlalchemy import Integer, Select, and_, case, cast, func, or_, select, text
+from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.exceptions import AppException, BadRequestError, ConflictError, NotFoundError
@@ -2138,7 +2137,7 @@ async def refresh_gene_skills(db: AsyncSession, gene_slugs: list[str]) -> dict:
 async def uninstall_gene(db: AsyncSession, instance_id: str, gene_id: str) -> dict:
     from app.services.instance_service import get_instance
 
-    instance = await get_instance(instance_id, db)
+    await get_instance(instance_id, db)
 
     ig_result = await db.execute(
         select(InstanceGene).where(

--- a/nodeskclaw-backend/app/services/genehub_client.py
+++ b/nodeskclaw-backend/app/services/genehub_client.py
@@ -8,7 +8,7 @@ RegistryAdapter interface.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 import httpx

--- a/nodeskclaw-backend/app/services/genehub_converter.py
+++ b/nodeskclaw-backend/app/services/genehub_converter.py
@@ -10,7 +10,7 @@ NoDeskClaw frontends expect UUID-based ids and specific field names.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 

--- a/nodeskclaw-backend/app/services/health_checker.py
+++ b/nodeskclaw-backend/app/services/health_checker.py
@@ -8,9 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.models.cluster import Cluster, ClusterStatus
-from app.services.k8s.client_manager import k8s_manager
 from app.services.k8s.event_bus import event_bus
-from app.services.k8s.k8s_client import K8sClient
 
 logger = logging.getLogger(__name__)
 

--- a/nodeskclaw-backend/app/services/instance_member_service.py
+++ b/nodeskclaw-backend/app/services/instance_member_service.py
@@ -4,7 +4,6 @@ import logging
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import BadRequestError, ConflictError, ForbiddenError, NotFoundError
 from app.models.admin_membership import AdminMembership
@@ -118,7 +117,7 @@ def apply_accessible_filter(query, user_id: str, org_id: str | None, db: AsyncSe
         )
     )
 
-    from sqlalchemy import case, or_
+    from sqlalchemy import or_
     query = query.where(
         or_(
             org_admin_subq,

--- a/nodeskclaw-backend/app/services/instance_service.py
+++ b/nodeskclaw-backend/app/services/instance_service.py
@@ -78,7 +78,6 @@ def _k8s_name(instance: Instance) -> str:
 
 def _build_docker_handle(instance: Instance) -> "ComputeHandle":
     from app.services.runtime.compute.base import ComputeHandle
-    env_vars = json.loads(instance.env_vars) if instance.env_vars else {}
     advanced = json.loads(instance.advanced_config) if instance.advanced_config else {}
     return ComputeHandle(
         provider="docker", instance_id=instance.id,
@@ -359,8 +358,6 @@ async def delete_instance(instance_id: str, db: AsyncSession, delete_k8s: bool =
             message="该实例已加入办公室，请先从办公室中移除",
             message_key="errors.instance.still_in_workspace",
         )
-
-    ws_ids = await _get_instance_workspace_ids(db, instance_id)
 
     if delete_k8s:
         if instance.compute_provider == "docker":
@@ -955,7 +952,7 @@ async def rollback_instance(
     instance_id: str, target_revision: int, user_id: str, db: AsyncSession
 ) -> InstanceInfo:
     """回滚实例到指定版本。"""
-    instance = await get_instance(instance_id, db)
+    await get_instance(instance_id, db)
 
     # 查找目标版本记录
     result = await db.execute(

--- a/nodeskclaw-backend/app/services/local_adapter.py
+++ b/nodeskclaw-backend/app/services/local_adapter.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker

--- a/nodeskclaw-backend/app/services/nfs_mount.py
+++ b/nodeskclaw-backend/app/services/nfs_mount.py
@@ -102,7 +102,7 @@ class PodFS:
 
     async def exists(self, path: str) -> bool:
         try:
-            result = await self._k8s.exec_in_pod(
+            await self._k8s.exec_in_pod(
                 self._ns, self._pod,
                 ["test", "-e", f"/root/{path}"],
                 container=self._container,
@@ -312,7 +312,6 @@ class DockerFS:
         os.makedirs(str(self._base), exist_ok=True)
 
     def _resolve(self, remote_path: str) -> "pathlib.Path":
-        import pathlib
         abs_slash = self._abs_prefix + "/"
         if remote_path.startswith(abs_slash):
             rel = remote_path[len(abs_slash):]

--- a/nodeskclaw-backend/app/services/registry_aggregator.py
+++ b/nodeskclaw-backend/app/services/registry_aggregator.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
 
 from app.services.registry_adapter import (
     RegistryAdapter,

--- a/nodeskclaw-backend/app/services/runtime/messaging/event_log.py
+++ b/nodeskclaw-backend/app/services/runtime/messaging/event_log.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/nodeskclaw-backend/app/services/runtime/messaging/queue.py
+++ b/nodeskclaw-backend/app/services/runtime/messaging/queue.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import math
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select, text, update
@@ -72,7 +71,7 @@ async def dequeue(
     Lower virtual_time = higher effective priority, preventing starvation
     because old low-priority messages eventually gain precedence.
     """
-    from sqlalchemy import case, extract, func
+    from sqlalchemy import case, extract
 
     weight_expr = case(
         (MessageQueueItem.priority == PRIORITY_WEIGHT[Priority.CRITICAL], 8),

--- a/nodeskclaw-backend/app/services/runtime/messaging/queue_consumer.py
+++ b/nodeskclaw-backend/app/services/runtime/messaging/queue_consumer.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import time
 
 logger = logging.getLogger(__name__)
 

--- a/nodeskclaw-backend/app/services/runtime/migration.py
+++ b/nodeskclaw-backend/app/services/runtime/migration.py
@@ -7,9 +7,8 @@ data into the unified node_cards table. Safe to run multiple times (idempotent).
 from __future__ import annotations
 
 import logging
-import uuid
 
-from sqlalchemy import select, text
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import not_deleted

--- a/nodeskclaw-backend/app/services/runtime/registries/runtime_registry.py
+++ b/nodeskclaw-backend/app/services/runtime/registries/runtime_registry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)

--- a/nodeskclaw-backend/app/services/runtime/retention.py
+++ b/nodeskclaw-backend/app/services/runtime/retention.py
@@ -8,7 +8,6 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy import delete, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.base import not_deleted
 
 logger = logging.getLogger(__name__)
 

--- a/nodeskclaw-backend/app/services/runtime/sse_registry.py
+++ b/nodeskclaw-backend/app/services/runtime/sse_registry.py
@@ -12,7 +12,7 @@ import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import delete, select, update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import not_deleted

--- a/nodeskclaw-backend/app/services/runtime/transport/channel_transport.py
+++ b/nodeskclaw-backend/app/services/runtime/transport/channel_transport.py
@@ -251,7 +251,6 @@ class ChannelTransportAdapter:
         source_name = data.sender.name if data else "System"
         content = data.content if data else ""
 
-        from app.models.node_card import NodeCard
 
         if db is None:
             from app.core.deps import async_session_factory

--- a/nodeskclaw-backend/app/services/schedule_runner.py
+++ b/nodeskclaw-backend/app/services/schedule_runner.py
@@ -7,7 +7,6 @@ from datetime import datetime, timezone
 from croniter import croniter
 from sqlalchemy import select
 
-from app.models.workspace import Workspace
 from app.models.workspace_agent import WorkspaceAgent
 from app.models.workspace_schedule import WorkspaceSchedule
 

--- a/nodeskclaw-backend/app/services/tunnel/protocol.py
+++ b/nodeskclaw-backend/app/services/tunnel/protocol.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 import uuid
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 


### PR DESCRIPTION
## Summary

- 使用 ruff 自动修复 31 处 F401（unused import）
- 手动修复 5 处 F841（unused variable）：移除未使用的变量赋值，保留有副作用的函数调用
- 涉及 23 个文件，净减少 19 行代码

## Test plan

- [x] `ruff check app/services --select F401,F841` 全部通过

Made with [Cursor](https://cursor.com)