### PR TITLE
fix(mcp): 统一 MCP server apiFetch 错误处理

### DIFF
--- a/openclaw-channel-nodeskclaw/mcp-servers/nodeskclaw-blackboard-tools/index.ts
+++ b/openclaw-channel-nodeskclaw/mcp-servers/nodeskclaw-blackboard-tools/index.ts
@@ -12,12 +12,26 @@ const TOKEN = process.env.NODESKCLAW_TOKEN || "";
 const WORKSPACE_ID = process.env.NODESKCLAW_WORKSPACE_ID || "";
 
 async function apiFetch(path: string, method = "GET", body?: unknown) {
-  const res = await fetch(`${API}${path}`, {
-    method,
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  return res.json();
+  let res: Response;
+  try {
+    res = await fetch(`${API}${path}`, {
+      method,
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch (err) {
+    return { error: true, message: `Network error: ${(err as Error).message}` };
+  }
+  if (!res.ok) {
+    let detail: string;
+    try { detail = await res.text(); } catch { detail = ""; }
+    return { error: true, status: res.status, message: detail || res.statusText };
+  }
+  try {
+    return await res.json();
+  } catch {
+    return { error: true, message: "Response is not valid JSON" };
+  }
 }
 
 const server = new Server({ name: "nodeskclaw-blackboard-tools", version: "1.0.0" }, { capabilities: { tools: {} } });

--- a/openclaw-channel-nodeskclaw/mcp-servers/nodeskclaw-gene-discovery/index.ts
+++ b/openclaw-channel-nodeskclaw/mcp-servers/nodeskclaw-gene-discovery/index.ts
@@ -11,12 +11,26 @@ const API = process.env.NODESKCLAW_API_URL || "http://localhost:4510/api/v1";
 const TOKEN = process.env.NODESKCLAW_TOKEN || "";
 
 async function apiFetch(path: string, method = "GET", body?: unknown) {
-  const res = await fetch(`${API}${path}`, {
-    method,
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  return res.json();
+  let res: Response;
+  try {
+    res = await fetch(`${API}${path}`, {
+      method,
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch (err) {
+    return { error: true, message: `Network error: ${(err as Error).message}` };
+  }
+  if (!res.ok) {
+    let detail: string;
+    try { detail = await res.text(); } catch { detail = ""; }
+    return { error: true, status: res.status, message: detail || res.statusText };
+  }
+  try {
+    return await res.json();
+  } catch {
+    return { error: true, message: "Response is not valid JSON" };
+  }
 }
 
 const server = new Server({ name: "nodeskclaw-gene-discovery", version: "1.0.0" }, { capabilities: { tools: {} } });

--- a/openclaw-channel-nodeskclaw/mcp-servers/nodeskclaw-performance-reader/index.ts
+++ b/openclaw-channel-nodeskclaw/mcp-servers/nodeskclaw-performance-reader/index.ts
@@ -12,8 +12,22 @@ const TOKEN = process.env.NODESKCLAW_TOKEN || "";
 const WORKSPACE_ID = process.env.NODESKCLAW_WORKSPACE_ID || "";
 
 async function apiFetch(path: string, method = "GET") {
-  const res = await fetch(`${API}${path}`, { method, headers: { Authorization: `Bearer ${TOKEN}` } });
-  return res.json();
+  let res: Response;
+  try {
+    res = await fetch(`${API}${path}`, { method, headers: { Authorization: `Bearer ${TOKEN}` } });
+  } catch (err) {
+    return { error: true, message: `Network error: ${(err as Error).message}` };
+  }
+  if (!res.ok) {
+    let detail: string;
+    try { detail = await res.text(); } catch { detail = ""; }
+    return { error: true, status: res.status, message: detail || res.statusText };
+  }
+  try {
+    return await res.json();
+  } catch {
+    return { error: true, message: "Response is not valid JSON" };
+  }
 }
 
 const server = new Server({ name: "nodeskclaw-performance-reader", version: "1.0.0" }, { capabilities: { tools: {} } });

--- a/openclaw-channel-nodeskclaw/mcp-servers/nodeskclaw-proposals/index.ts
+++ b/openclaw-channel-nodeskclaw/mcp-servers/nodeskclaw-proposals/index.ts
@@ -12,12 +12,26 @@ const TOKEN = process.env.NODESKCLAW_TOKEN || "";
 const WORKSPACE_ID = process.env.NODESKCLAW_WORKSPACE_ID || "";
 
 async function apiFetch(path: string, method = "GET", body?: unknown) {
-  const res = await fetch(`${API}${path}`, {
-    method,
-    headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
-    body: body ? JSON.stringify(body) : undefined,
-  });
-  return res.json();
+  let res: Response;
+  try {
+    res = await fetch(`${API}${path}`, {
+      method,
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${TOKEN}` },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  } catch (err) {
+    return { error: true, message: `Network error: ${(err as Error).message}` };
+  }
+  if (!res.ok) {
+    let detail: string;
+    try { detail = await res.text(); } catch { detail = ""; }
+    return { error: true, status: res.status, message: detail || res.statusText };
+  }
+  try {
+    return await res.json();
+  } catch {
+    return { error: true, message: "Response is not valid JSON" };
+  }
 }
 
 const server = new Server({ name: "nodeskclaw-proposals", version: "1.0.0" }, { capabilities: { tools: {} } });
@@ -41,7 +55,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
       break;
     case "check_trust_policy": {
       const a = args as any;
-      result = await apiFetch(`/workspaces/trust-policies/check?workspace_id=${ws}&agent_instance_id=${a.agent_instance_id}&action_type=${a.action_type}`);
+      result = await apiFetch(`/workspaces/trust-policies/check?workspace_id=${ws}&agent_instance_id=${a.agent_instance_id}&action_type=${encodeURIComponent(a.action_type)}`);
       break;
     }
     case "list_my_decisions": {


### PR DESCRIPTION
## Summary

- 4 个 MCP server（blackboard-tools、proposals、gene-discovery、performance-reader）的 `apiFetch` 函数增加三层防护：
  1. `try/catch` 捕获网络异常（DNS 解析失败、连接超时等）
  2. `res.ok` 检查 HTTP 4xx/5xx 错误
  3. `res.json()` 异常保护（非 JSON 响应）
- 与 `tools.ts` 的已修复实现保持一致
- 修复 `proposals/index.ts` 中 `action_type` 查询参数缺少 `encodeURIComponent`

## Test plan

- [ ] 模拟后端不可达时，MCP tool 返回结构化错误而非抛出 unhandled exception
- [ ] 后端返回 500 时，错误信息包含 HTTP 状态码

Made with [Cursor](https://cursor.com)