### PR TITLE
fix(dingtalk): token 缓存 TTL 使用接口返回的 expireIn

### DIFF
--- a/openclaw-channel-dingtalk/src/send.ts
+++ b/openclaw-channel-dingtalk/src/send.ts
@@ -1,7 +1,7 @@
 import type { SessionWebhookEntry, ResolvedDingTalkAccount } from "./types.js";
 
 const DINGTALK_API = "https://api.dingtalk.com";
-const TOKEN_CACHE_TTL_MS = 7000 * 1000;
+const TOKEN_CACHE_SAFETY_MARGIN_MS = 5 * 60 * 1000;
 
 const webhookStore = new Map<string, SessionWebhookEntry>();
 
@@ -44,9 +44,10 @@ async function getAccessToken(account: ResolvedDingTalkAccount): Promise<string>
   }
 
   const body = (await resp.json()) as { accessToken: string; expireIn: number };
+  const ttlMs = (body.expireIn > 0 ? body.expireIn : 7200) * 1000 - TOKEN_CACHE_SAFETY_MARGIN_MS;
   cachedToken = {
     token: body.accessToken,
-    expiresAt: Date.now() + TOKEN_CACHE_TTL_MS,
+    expiresAt: Date.now() + Math.max(ttlMs, 60_000),
   };
 
   return body.accessToken;


### PR DESCRIPTION
## Summary

- 钉钉 access token 缓存 TTL 从硬编码 7000 秒改为使用 API 响应中的 `expireIn` 字段
- 减去 5 分钟安全余量防止边界时刻 token 失效，兜底不低于 60 秒
- 接口未返回 `expireIn` 时回退到默认 7200 秒（钉钉标准过期时间）

## Test plan

- [ ] 验证 token 缓存在接近过期时间时自动刷新
- [ ] 验证接口返回异常 `expireIn`（0 或负数）时回退到默认值

Made with [Cursor](https://cursor.com)