### PR TITLE
fix(backend): 增强协作时间线日期参数校验

### DIFF
--- a/nodeskclaw-backend/app/api/workspaces.py
+++ b/nodeskclaw-backend/app/api/workspaces.py
@@ -1021,14 +1021,16 @@ async def list_collaboration_timeline(
 ):
     """List all collaboration messages in a workspace as a timeline."""
     await wm_service.check_workspace_member(workspace_id, user, db)
-    from datetime import datetime as dt
+    from datetime import datetime as dt, timezone
+    since_dt = None
     if since:
+        normalized = since.replace("Z", "+00:00") if since.endswith("Z") else since
         try:
-            since_dt = dt.fromisoformat(since)
-        except ValueError:
-            raise HTTPException(status_code=400, detail="since 参数格式无效，请使用 ISO 8601 格式")
-    else:
-        since_dt = None
+            since_dt = dt.fromisoformat(normalized)
+        except (ValueError, TypeError):
+            raise _error(400, 40003, "errors.validation.invalid_date", "Invalid date format")
+        if since_dt.tzinfo is None:
+            since_dt = since_dt.replace(tzinfo=timezone.utc)
     messages = await msg_service.get_collaboration_timeline(
         db, workspace_id, limit, since_dt,
     )


### PR DESCRIPTION
## Summary

从 @chenchenchenchencj 的 #66 中提取并应用日期校验改进（commit 保留原作者归属）：

- 处理 ISO 8601 `"Z"` 后缀（替换为 `+00:00`）
- 捕获 `TypeError` + `ValueError`
- 无时区信息时默认 UTC
- 使用 `_error()` + i18n key 替代硬编码 `HTTPException`

#66 中的软删除修复部分已由 #90 覆盖，工具名提取已由现有 `NODESKCLAW_CHANNEL_TOOLS` 常量覆盖，网络异常捕获已存在于代码中。

## Test plan

- [ ] 传入 `since=2026-03-01T00:00:00Z` 正常解析
- [ ] 传入 `since=invalid` 返回 400 + `errors.validation.invalid_date`

Made with [Cursor](https://cursor.com)