### PR TITLE
fix(docker): 修复 ZeroClaw v0.5.0 Docker 部署启动失败

### DIFF
--- a/nodeskclaw-backend/app/services/runtime/compute/docker_provider.py
+++ b/nodeskclaw-backend/app/services/runtime/compute/docker_provider.py
@@ -145,6 +145,9 @@ def _build_compose_yaml(config: InstanceComputeConfig) -> dict:
         "extra_hosts": ["host.docker.internal:host-gateway"],
     }
 
+    if rt_spec and rt_spec.docker_command:
+        main_service["command"] = list(rt_spec.docker_command)
+
     if config.mem_limit:
         main_service["mem_limit"] = _parse_mem(config.mem_limit)
     if config.cpu_limit:

--- a/nodeskclaw-backend/app/services/runtime/registries/runtime_registry.py
+++ b/nodeskclaw-backend/app/services/runtime/registries/runtime_registry.py
@@ -36,6 +36,7 @@ class RuntimeSpec:
     scripts_dir_rel: str = ".deskclaw/tools"
     has_web_ui: bool = True
     has_init_script: bool = True
+    docker_command: tuple[str, ...] | None = None
 
 
 class RuntimeRegistry:
@@ -93,6 +94,7 @@ def _register_builtins() -> None:
         display_powered_by="ZeroClaw",
         gateway_port=8080,
         health_probe_path="/health",
+        docker_command=("zeroclaw", "gateway", "start", "-p", "8080", "--host", "0.0.0.0"),
         order=1,
         image_registry_key="image_registry_zeroclaw",
         config_rel_path=".zeroclaw/config.toml",


### PR DESCRIPTION
## Summary
- ZeroClaw v0.5.0 将 `--port` 参数移到了 `gateway start` 子命令下，镜像默认 CMD `zeroclaw gateway --port 8080` 不再兼容，导致容器 CrashLoopBackOff
- `RuntimeSpec` 新增 `docker_command` 字段，zeroclaw 注册时设置正确的启动命令 `zeroclaw gateway start -p 8080 --host 0.0.0.0`
- `docker_provider` 生成 compose 时写入 `command` 覆盖镜像默认 CMD

## Test plan
- [ ] 使用 ZeroClaw v0.5.0 镜像创建 Docker 实例，确认容器正常启动不再报 `unexpected argument '--port'`
- [ ] 确认 OpenClaw 和 Nanobot 实例不受影响（docker_command 为 None 时不写入 command）

Closes #86

Made with [Cursor](https://cursor.com)