### PR TITLE
fix(backend): 消除静默异常吞没 + pg_notify 参数化

### DIFF
--- a/nodeskclaw-backend/app/api/clusters.py
+++ b/nodeskclaw-backend/app/api/clusters.py
@@ -1,6 +1,10 @@
 """Cluster management endpoints."""
 
+import logging
+
 from fastapi import APIRouter, Depends
+
+logger = logging.getLogger(__name__)
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -139,7 +143,7 @@ async def cluster_overview(
                 "enabled": sc.metadata.name in allowed_names,
             })
     except Exception:
-        pass  # StorageClass 获取失败不影响概览
+        logger.warning("Failed to list StorageClasses for cluster %s", cluster_id, exc_info=True)
 
     # 获取 IngressClass 列表
     ingress_classes = []
@@ -154,7 +158,7 @@ async def cluster_overview(
                 "controller": ic.spec.controller if ic.spec else "",
             })
     except Exception:
-        pass
+        logger.warning("Failed to list IngressClasses for cluster %s", cluster_id, exc_info=True)
 
     return ApiResponse(data={
         "summary": summary,

--- a/nodeskclaw-backend/app/api/organizations.py
+++ b/nodeskclaw-backend/app/api/organizations.py
@@ -1,6 +1,10 @@
 """Organization management endpoints."""
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, status
+
+logger = logging.getLogger(__name__)
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -266,7 +270,7 @@ async def remove_member(
         try:
             await get_member_hook().on_member_removed(org_id, removed_user_id)
         except Exception:
-            pass
+            logger.exception("on_member_removed hook failed for org=%s user=%s", org_id, removed_user_id)
     return ApiResponse(message="成员已移除")
 
 

--- a/nodeskclaw-backend/app/api/workspaces.py
+++ b/nodeskclaw-backend/app/api/workspaces.py
@@ -1270,7 +1270,7 @@ async def workspace_events(
                     await sse_registry.unregister_connection(cleanup_db, conn_id)
                     await cleanup_db.commit()
             except Exception:
-                pass
+                logger.warning("SSE cleanup failed for conn %s", conn_id, exc_info=True)
 
     return StreamingResponse(stream(), media_type="text/event-stream")
 

--- a/nodeskclaw-backend/app/main.py
+++ b/nodeskclaw-backend/app/main.py
@@ -722,14 +722,14 @@ async def lifespan(app: FastAPI):
             try:
                 await _pg_notify_service.stop_listening(_asyncpg_conn, _pg_notify_channels)
             except Exception:
-                pass
+                logger.warning("Failed to stop PG NOTIFY listeners", exc_info=True)
         try:
             async with async_session_factory() as _shutdown_db:
                 from app.services.runtime import sse_registry
                 await sse_registry.cleanup_backend_connections(_shutdown_db)
                 await _shutdown_db.commit()
         except Exception:
-            pass
+            logger.warning("Failed to cleanup SSE backend connections", exc_info=True)
         from app.services.runtime.failure_recovery import shutdown_cleanup
         await shutdown_cleanup(async_session_factory)
         logger.info("Runtime v2: 已清理")

--- a/nodeskclaw-backend/app/services/cluster_service.py
+++ b/nodeskclaw-backend/app/services/cluster_service.py
@@ -213,6 +213,7 @@ async def update_kubeconfig(cluster_id: str, kubeconfig: str, db: AsyncSession) 
         cluster.set_provider_value("k8s_version", info.git_version)
         cluster.health_status = "healthy"
     except Exception:
+        logger.warning("KubeConfig connectivity test failed for cluster %s", cluster_id, exc_info=True)
         cluster.status = ClusterStatus.disconnected
         cluster.health_status = "unhealthy"
 

--- a/nodeskclaw-backend/app/services/deploy_service.py
+++ b/nodeskclaw-backend/app/services/deploy_service.py
@@ -983,7 +983,7 @@ async def _execute_deploy_inner(ctx, async_session_factory, get_config, total, s
                             sc = pvc.spec.storage_class_name or "(默认)"
                             diag_lines.append(f"PVC {pvc.metadata.name}: {pvc_phase} (StorageClass: {sc})")
                     except Exception:
-                        pass
+                        logger.warning("Failed to list PVCs for deploy diag in %s", ctx.namespace, exc_info=True)
 
                     # ── K8s Events（最近 5 条） ──
                     try:
@@ -992,7 +992,7 @@ async def _execute_deploy_inner(ctx, async_session_factory, get_config, total, s
                         for ev in recent:
                             diag_lines.append(f"Event: {ev.reason} — {(ev.message or '')[:200]}")
                     except Exception:
-                        pass
+                        logger.warning("Failed to list Events for deploy diag in %s", ctx.namespace, exc_info=True)
 
                     # ── Deployment conditions ──
                     for cond in dep_status.get("conditions", []):
@@ -1100,7 +1100,7 @@ async def _execute_deploy_inner(ctx, async_session_factory, get_config, total, s
                             from app.services.instance_template_service import increment_use_count
                             await increment_use_count(db, ctx.template_id)
                         except Exception:
-                            pass
+                            logger.warning("Failed to increment template use count for %s", ctx.template_id, exc_info=True)
 
                 success_msg = f"部署成功{llm_sync_warning}{gene_install_warning}"
                 _publish(total, "完成", status="success", message=success_msg)

--- a/nodeskclaw-backend/app/services/k8s/k8s_client.py
+++ b/nodeskclaw-backend/app/services/k8s/k8s_client.py
@@ -126,7 +126,7 @@ class K8sClient:
                     "mem_used": _parse_memory(usage.get("memory", "0")),
                 }
         except Exception:
-            pass  # metrics-server may not be available
+            logger.debug("metrics-server not available, skipping node metrics", exc_info=True)
 
         results = []
         for n in nodes.items:

--- a/nodeskclaw-backend/app/services/runtime/companion.py
+++ b/nodeskclaw-backend/app/services/runtime/companion.py
@@ -83,6 +83,7 @@ class CompanionClient:
             )
             return resp.status_code == 200
         except Exception:
+            logger.debug("Companion health check failed for %s", self._config.base_url, exc_info=True)
             return False
 
     async def status(self) -> CompanionStatus:
@@ -102,7 +103,7 @@ class CompanionClient:
                     extra=data,
                 )
         except Exception:
-            pass
+            logger.debug("Companion status check failed for %s", self._config.base_url, exc_info=True)
         return CompanionStatus(healthy=False)
 
     async def cancel(self, session_id: str = "") -> bool:
@@ -115,6 +116,7 @@ class CompanionClient:
             )
             return resp.status_code == 200
         except Exception:
+            logger.debug("Companion cancel failed for %s", self._config.base_url, exc_info=True)
             return False
 
     async def capabilities(self) -> CompanionCapabilities:
@@ -135,7 +137,7 @@ class CompanionClient:
                     extra=data,
                 )
         except Exception:
-            pass
+            logger.debug("Companion capabilities check failed for %s", self._config.base_url, exc_info=True)
         return CompanionCapabilities()
 
     async def close(self) -> None:

--- a/nodeskclaw-backend/app/services/runtime/compute/docker_provider.py
+++ b/nodeskclaw-backend/app/services/runtime/compute/docker_provider.py
@@ -292,7 +292,7 @@ class DockerComputeProvider:
                 status_map = {"running": "running", "exited": "stopped", "paused": "stopped"}
                 return status_map.get(status, status)
         except Exception:
-            pass
+            logger.warning("docker inspect failed for slug=%s", slug, exc_info=True)
         return "unknown"
 
     async def get_endpoint(self, handle: ComputeHandle) -> str:

--- a/nodeskclaw-backend/app/services/runtime/messaging/queue.py
+++ b/nodeskclaw-backend/app/services/runtime/messaging/queue.py
@@ -52,9 +52,9 @@ async def enqueue(
 
     try:
         payload = json.dumps({"target_node_id": target_node_id})
-        await db.execute(text(f"SELECT pg_notify('message_enqueued', :payload)"), {"payload": payload})
+        await db.execute(text("SELECT pg_notify('message_enqueued', :payload)"), {"payload": payload})
     except Exception:
-        pass
+        logger.warning("pg_notify for message_enqueued failed (node=%s)", target_node_id, exc_info=True)
 
     return item
 

--- a/nodeskclaw-backend/app/services/runtime/messaging/queue_consumer.py
+++ b/nodeskclaw-backend/app/services/runtime/messaging/queue_consumer.py
@@ -108,7 +108,7 @@ async def _consume_loop(session_factory) -> None:
                         try:
                             await nack(db, str(item.id), str(e))
                         except Exception:
-                            pass
+                            logger.warning("QueueConsumer: nack also failed for item %s", item.id, exc_info=True)
 
                 await db.commit()
 

--- a/nodeskclaw-backend/app/services/runtime/pg_notify.py
+++ b/nodeskclaw-backend/app/services/runtime/pg_notify.py
@@ -44,9 +44,10 @@ class PGNotifyService:
 
     @staticmethod
     async def notify(db: AsyncSession, channel: str, payload: str = "") -> None:
-        safe_channel = channel.replace("'", "''")
-        safe_payload = payload.replace("'", "''")
-        await db.execute(text(f"SELECT pg_notify('{safe_channel}', '{safe_payload}')"))
+        await db.execute(
+            text("SELECT pg_notify(:channel, :payload)"),
+            {"channel": channel, "payload": payload},
+        )
 
     @staticmethod
     async def notify_topology_changed(db: AsyncSession, workspace_id: str) -> None:

--- a/nodeskclaw-backend/app/services/tunnel/adapter.py
+++ b/nodeskclaw-backend/app/services/tunnel/adapter.py
@@ -132,7 +132,7 @@ class TunnelAdapter:
             try:
                 await ws.close(code=4001, reason="auth_timeout")
             except Exception:
-                pass
+                logger.warning("Tunnel: failed to close ws after auth timeout", exc_info=True)
             return
 
         auth_msg = TunnelMessage.from_dict(raw)
@@ -170,7 +170,7 @@ class TunnelAdapter:
             try:
                 await old_conn.ws.close(code=4010, reason="replaced")
             except Exception:
-                pass
+                logger.warning("Tunnel: failed to close old ws for %s", instance_id, exc_info=True)
             self._cleanup_instance(instance_id)
 
         conn = _InstanceConnection(ws, instance_id)
@@ -741,7 +741,7 @@ class TunnelAdapter:
                     try:
                         await conn.ws.close(code=4020, reason="ping_timeout")
                     except Exception:
-                        pass
+                        logger.warning("Tunnel: failed to close ws on ping timeout for %s", instance_id, exc_info=True)
                     break
                 try:
                     await self._send(conn.ws, TunnelMessage(type=TunnelMessageType.PING))


### PR DESCRIPTION
## Summary

- `pg_notify.py`: SQL 字符串拼接改为参数化绑定 `text("SELECT pg_notify(:channel, :payload)")`，消除注入面
- 后端 18 处 `except Exception: pass` 补充 logger 输出（13 个文件），消除静默异常吞没：
  - **7 处关闭/清理路径**（SSE 注销、stop_listening、ws.close 等）→ `logger.warning`
  - **11 处业务逻辑路径**（StorageClass 拉取、成员钩子、部署诊断、pg_notify 入队等）→ `logger.exception` / `logger.warning`
  - `companion.py` 高频健康检查路径 → `logger.debug`（避免刷日志）
  - `k8s_client.py` metrics-server 不可用 → `logger.debug`
- `queue.py` 额外修复一处 f-string `pg_notify` 为参数化

## Test plan

- [ ] 后端正常启动，无 import 错误
- [ ] 触发 SSE 连接断开，确认 warning 日志输出
- [ ] companion 不可达时确认 debug 日志输出而非静默

Made with [Cursor](https://cursor.com)