### PR TITLE
fix(portal): 邀请登录鉴权修复 + 错误处理增强

### DIFF
--- a/nodeskclaw-portal/src/stores/workspace.ts
+++ b/nodeskclaw-portal/src/stores/workspace.ts
@@ -586,6 +586,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       await api.post(`/workspaces/${workspaceId}/chat`, body)
     } catch (e) {
       console.error('sendWorkspaceMessage error:', e)
+      throw e
     } finally {
       chatLoading.value = false
     }
@@ -596,6 +597,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
       await api.post(`/workspaces/${workspaceId}/system-message`, { content })
     } catch (e) {
       console.error('sendSystemMessage error:', e)
+      throw e
     }
   }
 

--- a/nodeskclaw-portal/src/views/AcceptInvite.vue
+++ b/nodeskclaw-portal/src/views/AcceptInvite.vue
@@ -77,10 +77,7 @@ async function handleAccept() {
 
     const data = res.data.data
     if (data.access_token) {
-      localStorage.setItem('token', data.access_token)
-      if (data.refresh_token) {
-        localStorage.setItem('refreshToken', data.refresh_token)
-      }
+      authStore.setTokens(data.access_token, data.refresh_token || '')
       await authStore.fetchUser()
       router.push('/')
     }

--- a/nodeskclaw-portal/src/views/ClusterDetail.vue
+++ b/nodeskclaw-portal/src/views/ClusterDetail.vue
@@ -52,7 +52,7 @@ const ingressClassOptions = computed(() => {
 onMounted(async () => {
   try {
     await clusterStore.fetchCluster(clusterId.value)
-    clusterStore.fetchOverview(clusterId.value)
+    await clusterStore.fetchOverview(clusterId.value)
   } finally {
     loading.value = false
   }

--- a/nodeskclaw-portal/src/views/DeployProgress.vue
+++ b/nodeskclaw-portal/src/views/DeployProgress.vue
@@ -198,6 +198,10 @@ function subscribeSSE() {
     },
   }).catch((e) => {
     if (e instanceof DOMException && e.name === 'AbortError') return
+    if (finalStatus.value === 'in_progress') {
+      finalStatus.value = 'failed'
+      finalMessage.value = 'SSE 连接异常，请刷新页面或在AI 员工列表查看部署状态'
+    }
   })
 }
 


### PR DESCRIPTION
## Summary

- **AcceptInvite.vue**: `localStorage.setItem('token', ...)` 改为 `authStore.setTokens()`，修复邀请链接登录后 token 写入错误 key 导致未鉴权的问题
- **workspace.ts**: `sendWorkspaceMessage` / `sendSystemMessage` 失败时 re-throw，让调用方（ChatPanel）捕获并 toast 提示
- **ClusterDetail.vue**: `fetchOverview` 加 `await`，避免浮动 Promise 未处理拒绝
- **DeployProgress.vue**: SSE `.catch` 补充非 AbortError 处理，连接异常时设置 `failed` 状态而非永远卡在"部署中"

### 前端表现变化

- **邀请接受页**：邀请链接登录后无法进入系统 -> 修复后正常登录
- **工作区聊天**：发消息失败时无提示 -> 修复后上层可捕获并 toast
- **部署进度页**：SSE 断开时永远卡在"部署中" -> 修复后显示连接异常提示

## Test plan

- [ ] 通过邀请链接注册，确认登录后能正常访问首页
- [ ] 模拟发消息 API 失败，确认错误被 throw 到调用方
- [ ] 集群详情页正常加载概览数据
- [ ] 部署进度页断网后显示连接异常提示

Made with [Cursor](https://cursor.com)