### PR TITLE
chore(backend): 移除 channel_config_service 中无效的空循环

### DIFF
--- a/nodeskclaw-backend/app/services/channel_config_service.py
+++ b/nodeskclaw-backend/app/services/channel_config_service.py
@@ -291,9 +291,6 @@ async def _discover_openclaw_channels(
 
     channels.sort(key=lambda c: (c["order"], c["id"]))
 
-    for info in REPO_CHANNEL_PLUGINS.values():
-        pass
-
     return channels
 
 


### PR DESCRIPTION
## Summary

删除 `channel_config_service.py` 中 `for info in REPO_CHANNEL_PLUGINS.values(): pass` 空循环，属于未完成的死代码。

## Test plan

- [ ] 后端正常启动
- [ ] Channel 列表接口返回正常

Made with [Cursor](https://cursor.com)