### PR TITLE
fix(channel): 修复工作区内 @回复模型选择

### DIFF
--- a/openclaw-channel-nodeskclaw/src/tunnel-client.ts
+++ b/openclaw-channel-nodeskclaw/src/tunnel-client.ts
@@ -43,6 +43,25 @@ function deriveTunnelUrl(apiUrl: string): string {
   return `${wsUrl}/tunnel/connect`;
 }
 
+function deriveDefaultChatModel(cfg: OpenClawConfig): string {
+  const agents = (cfg as Record<string, unknown>).agents as Record<string, unknown> | undefined;
+  const defaults = agents?.defaults as Record<string, unknown> | undefined;
+  const model = defaults?.model;
+
+  if (typeof model === "string" && model.trim()) {
+    return model.trim();
+  }
+
+  if (model && typeof model === "object") {
+    const primary = (model as Record<string, unknown>).primary;
+    if (typeof primary === "string" && primary.trim()) {
+      return primary.trim();
+    }
+  }
+
+  return process.env.OPENCLAW_DEFAULT_MODEL || "gpt-4";
+}
+
 export function startTunnelClient(cfg: OpenClawConfig, callbacks?: TunnelCallbacks): TunnelClient {
   if (_instance) {
     console.log("[tunnel] Shutting down previous TunnelClient before re-init");
@@ -66,6 +85,7 @@ export function startTunnelClient(cfg: OpenClawConfig, callbacks?: TunnelCallbac
 
   const instanceId = defaultAccount?.instanceId ?? "";
   const token = defaultAccount?.apiToken ?? "";
+  const defaultChatModel = deriveDefaultChatModel(cfg);
 
   if (!tunnelUrl || !instanceId || !token) {
     console.warn(
@@ -74,7 +94,13 @@ export function startTunnelClient(cfg: OpenClawConfig, callbacks?: TunnelCallbac
       instanceId ? "set" : "MISSING",
       token ? "set" : "MISSING",
     );
-    _instance = new TunnelClient(tunnelUrl, instanceId, token, callbacks);
+    _instance = new TunnelClient(
+      tunnelUrl,
+      instanceId,
+      token,
+      defaultChatModel,
+      callbacks,
+    );
     return _instance;
   }
 
@@ -82,7 +108,13 @@ export function startTunnelClient(cfg: OpenClawConfig, callbacks?: TunnelCallbac
     console.log("[tunnel] Derived tunnelUrl from apiUrl: %s", tunnelUrl);
   }
 
-  _instance = new TunnelClient(tunnelUrl, instanceId, token, callbacks);
+  _instance = new TunnelClient(
+    tunnelUrl,
+    instanceId,
+    token,
+    defaultChatModel,
+    callbacks,
+  );
   _instance.connect();
   return _instance;
 }
@@ -105,6 +137,7 @@ export class TunnelClient {
     private backendUrl: string,
     private instanceId: string,
     private token: string,
+    private defaultChatModel: string,
     private callbacks?: TunnelCallbacks,
   ) {}
 
@@ -286,7 +319,7 @@ export class TunnelClient {
           ...(sessionKey ? { "X-OpenClaw-Session-Key": sessionKey } : {}),
         },
         body: JSON.stringify({
-          model: "gpt-4",
+          model: this.defaultChatModel,
           messages,
           stream: false,
           max_tokens: 1,
@@ -316,7 +349,7 @@ export class TunnelClient {
             : {}),
         },
         body: JSON.stringify({
-          model: "gpt-4",
+          model: this.defaultChatModel,
           messages,
           stream: true,
         }),


### PR DESCRIPTION
## 变更说明

修复工作区 tunnel 回复链路把本地 OpenClaw 聊天请求模型硬编码为 `gpt-4` 的问题。

## 根因

NoDeskClaw tunnel client 在处理 `chat.request` 时，向本地 OpenClaw ` /v1/chat/completions ` 发请求时始终传：

- `model: "gpt-4"`

但实例真实可用模型是由后端写入 `agents.defaults.model.primary` 决定的。升级到 OpenClaw `2026.3.24` 后，如果本地 API 对未配置模型名校验更严格，就会导致工作区内 `@` AI 员工时回复链路直接报错。

## 改动

- 新增 `deriveDefaultChatModel(cfg)`，从 `OpenClawConfig` 中读取实例默认模型
- 优先使用 `agents.defaults.model.primary`
- 兼容 `model` 为字符串的场景
- 仅在配置中取不到模型时，才回退到 `OPENCLAW_DEFAULT_MODEL` 或旧值 `gpt-4`
- tunnel client 的普通回复和 `no_reply` 上下文注入两条请求链路都改为使用解析后的默认模型

## 影响

- 工作区内 `@` 机器人回复时，会跟随实例自身配置的默认模型，不再强制走 `gpt-4`
- 对旧配置保持兼容，取不到模型时仍有兜底值

## 验证

- 已做源码级自检，确认两条 `/v1/chat/completions` 请求都改为使用实例默认模型
- 当前 `openclaw-channel-nodeskclaw` 包没有独立的构建/测试脚本，因此未执行自动化构建验证

## 关联

- refs #108