### PR TITLE
fix(image): 修复升级后旧会话索引丢失

### DIFF
--- a/nodeskclaw-artifacts/openclaw-image/Dockerfile
+++ b/nodeskclaw-artifacts/openclaw-image/Dockerfile
@@ -57,6 +57,7 @@ RUN mkdir -p /root/.openclaw/agents/main/sessions \
 
 # ---------- 配置模板 ----------
 COPY openclaw.json.template /root/.openclaw/openclaw.json.template
+COPY repair-sessions-index.js /repair-sessions-index.js
 
 # ---------- 版本标记 ----------
 RUN echo "${IMAGE_VERSION}" > /root/.openclaw-version

--- a/nodeskclaw-artifacts/openclaw-image/docker-entrypoint.sh
+++ b/nodeskclaw-artifacts/openclaw-image/docker-entrypoint.sh
@@ -94,6 +94,12 @@ if [ -f "${CONFIG_FILE}" ]; then
   "
 fi
 
+# ---- 1.2. 会话索引修复（兼容旧版会话文件命名） ----
+
+if [ -d "${OPENCLAW_DIR}/agents/main/sessions" ]; then
+  node /repair-sessions-index.js
+fi
+
 # ---- 2. 凭证注入 ----
 
 if [ -n "${OPENCLAW_CREDENTIALS_JSON:-}" ]; then

--- a/nodeskclaw-artifacts/openclaw-image/repair-sessions-index.js
+++ b/nodeskclaw-artifacts/openclaw-image/repair-sessions-index.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const openclawDir = process.env.OPENCLAW_DIR || "/root/.openclaw";
+const sessionsDir = path.join(openclawDir, "agents", "main", "sessions");
+const sessionsFile = path.join(sessionsDir, "sessions.json");
+const sessionFilePrefix = "/root/.openclaw/agents/main/sessions";
+
+function deriveSessionKey(stem) {
+  if (stem.startsWith("agent_main_")) {
+    return `agent:main:${stem.slice("agent_main_".length)}`;
+  }
+  return `agent:main:${stem}`;
+}
+
+function loadStore() {
+  if (!fs.existsSync(sessionsFile)) {
+    return {};
+  }
+
+  try {
+    const raw = fs.readFileSync(sessionsFile, "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch (error) {
+    console.warn(`[entrypoint] sessions.json 解析失败，跳过会话索引修复: ${error.message}`);
+  }
+
+  return null;
+}
+
+function main() {
+  if (!fs.existsSync(sessionsDir)) {
+    return;
+  }
+
+  const store = loadStore();
+  if (store === null) {
+    return;
+  }
+
+  const files = fs.readdirSync(sessionsDir)
+    .filter((name) => name.endsWith(".jsonl"))
+    .sort();
+
+  let changed = false;
+
+  for (const file of files) {
+    const stem = path.basename(file, ".jsonl");
+    const key = deriveSessionKey(stem);
+    const absoluteSessionFile = `${sessionFilePrefix}/${file}`;
+    const existing = store[key];
+
+    if (
+      existing &&
+      typeof existing === "object" &&
+      existing.sessionId === stem &&
+      existing.sessionFile === absoluteSessionFile
+    ) {
+      continue;
+    }
+
+    store[key] = {
+      ...(existing && typeof existing === "object" ? existing : {}),
+      sessionId: stem,
+      sessionFile: absoluteSessionFile,
+    };
+    changed = true;
+  }
+
+  if (!changed) {
+    return;
+  }
+
+  fs.writeFileSync(sessionsFile, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+  console.log(`[entrypoint] 已修复会话索引: ${files.length} 个会话文件已扫描`);
+}
+
+main();


### PR DESCRIPTION
## 变更说明

修复 OpenClaw 镜像在升级后旧会话 `.jsonl` 文件仍存在，但 `sessions.json` 索引没有同步补全，导致界面只显示 `main` 会话的问题。

## 根因

升级场景下，PVC 中可能还保留旧格式命名的会话文件，例如：

- `agent_main_main.jsonl`
- `agent_main_desk-d228bd66.jsonl`

但运行时依赖 `sessions.json` 作为会话索引。若索引中没有这些历史会话的条目，界面侧只能看到已经被索引的 `main`，旧会话文件虽然还在，却不会显示。

## 改动

- 新增 `repair-sessions-index.js`
- 在容器启动时扫描 `/root/.openclaw/agents/main/sessions/*.jsonl`
- 对缺失索引的历史会话文件自动补写 `sessions.json`
- 兼容旧命名 `agent_main_<session>.jsonl`，索引键映射为 `agent:main:<session>`
- 将该修复脚本加入 OpenClaw 镜像并在 entrypoint 中执行

## 影响

- 升级后遗留的旧会话文件会在下次容器启动时自动重新出现在索引中
- 不影响已经存在且正确的 `sessions.json` 条目
- 仅做索引补全，不改写历史 `.jsonl` 内容

## 验证

已用临时目录模拟以下场景进行验证：

- `sessions.json` 仅包含 `main`
- 会话目录中额外存在 `agent_main_desk-d228bd66.jsonl`

执行修复脚本后，`sessions.json` 自动补出：

- `agent:main:desk-d228bd66`

对应的 `sessionId` 和 `sessionFile` 条目。

## 关联

- refs #71