### PR TITLE
fix(backend): 补充 instance_llm_overrides 表的 Alembic 迁移文件

### DIFF
--- a/nodeskclaw-backend/alembic/versions/c8d4e1f2a3b5_add_instance_llm_overrides_table.py
+++ b/nodeskclaw-backend/alembic/versions/c8d4e1f2a3b5_add_instance_llm_overrides_table.py
@@ -1,0 +1,50 @@
+"""add instance_llm_overrides table
+
+Revision ID: c8d4e1f2a3b5
+Revises: b7d2e9f31a04
+Create Date: 2026-03-27 10:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'c8d4e1f2a3b5'
+down_revision: Union[str, Sequence[str], None] = 'b7d2e9f31a04'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'instance_llm_overrides',
+        sa.Column('id', sa.String(36), primary_key=True),
+        sa.Column('instance_id', sa.String(36), nullable=False, index=True),
+        sa.Column('provider', sa.String(32), nullable=False),
+        sa.Column('base_url', sa.String(512), nullable=True),
+        sa.Column('api_type', sa.String(32), nullable=True),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(['instance_id'], ['instances.id']),
+    )
+    op.create_index(
+        'ix_instance_llm_overrides_deleted_at',
+        'instance_llm_overrides',
+        ['deleted_at'],
+    )
+    op.create_index(
+        'uq_instance_llm_overrides_inst_provider',
+        'instance_llm_overrides',
+        ['instance_id', 'provider'],
+        unique=True,
+        postgresql_where=sa.text('deleted_at IS NULL'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('uq_instance_llm_overrides_inst_provider', table_name='instance_llm_overrides')
+    op.drop_index('ix_instance_llm_overrides_deleted_at', table_name='instance_llm_overrides')
+    op.drop_table('instance_llm_overrides')


### PR DESCRIPTION
## Summary
- bf666d4 新增 `InstanceLlmOverride` Model 和业务代码时遗漏了迁移文件，导致 `write_instance_llm_configs` 查询该表时触发 `UndefinedTableError`
- 补充 Alembic 迁移文件，包含 `deleted_at` 索引和 `(instance_id, provider)` 部分唯一索引

## Test plan
- [ ] `alembic upgrade head` 成功创建 `instance_llm_overrides` 表
- [ ] PUT `/api/v1/instances/{id}/llm-configs` 接口不再报 500