### PR TITLE
fix(image): 清理悬空会话索引

### DIFF
--- a/nodeskclaw-artifacts/openclaw-image/repair-sessions-index.js
+++ b/nodeskclaw-artifacts/openclaw-image/repair-sessions-index.js
@@ -46,8 +46,27 @@ function main() {
   const files = fs.readdirSync(sessionsDir)
     .filter((name) => name.endsWith(".jsonl"))
     .sort();
+  const knownFiles = new Set(files.map((file) => `${sessionFilePrefix}/${file}`));
 
   let changed = false;
+
+  for (const [key, value] of Object.entries(store)) {
+    if (!value || typeof value !== "object") {
+      continue;
+    }
+
+    const sessionFile = value.sessionFile;
+    if (typeof sessionFile !== "string" || !sessionFile.startsWith(sessionFilePrefix)) {
+      continue;
+    }
+
+    if (knownFiles.has(sessionFile)) {
+      continue;
+    }
+
+    delete store[key];
+    changed = true;
+  }
 
   for (const file of files) {
     const stem = path.basename(file, ".jsonl");


### PR DESCRIPTION
## 变更说明

补充 OpenClaw 会话索引修复脚本的自愈能力：当 `sessions.json` 中仍保留某个会话条目，但对应的 `.jsonl` 文件已经不存在时，启动时自动清理该悬空索引。

## 根因

当前镜像启动时虽然已经能把缺失的历史 `.jsonl` 文件补回 `sessions.json` 索引，但反方向的问题仍然存在：

- `sessions.json` 有条目
- 对应 `sessionFile` 指向的 `.jsonl` 已经被删除

这种情况下，运行时仍可能继续把该会话视为存在，导致手动删除主会话文件后，重启仍然无法真正清掉对应会话。

## 改动

- 在 `repair-sessions-index.js` 中新增悬空索引清理逻辑
- 启动时先扫描当前 `sessions` 目录下实际存在的 `.jsonl`
- 对 `sessions.json` 中指向缺失文件、且路径位于 `/root/.openclaw/agents/main/sessions/` 下的条目自动删除
- 保留仍然有效的索引条目
- 后续继续执行已有的“缺索引补索引”逻辑

## 影响

- 手动删除 `agent_main_main.jsonl` 这类会话文件后，重启不会再被旧索引复活
- 与上一版修复配合后，启动时会对会话索引做双向自愈：
  - 缺文件则删索引
  - 缺索引则补文件索引

## 验证

已用临时目录模拟以下场景验证：

- `sessions.json` 含有 `agent:main:old`
- 但 `agent_main_old.jsonl` 实际不存在
- 目录中另外存在 `agent_main_desk-d228bd66.jsonl`

执行脚本后结果符合预期：

- 缺失文件的旧索引被清掉
- 真实存在但缺索引的历史会话被补回

## 关联

- partial refs #81