### PR TITLE
fix(blackboard): 修复 AI 提及通知不触发回帖

### DIFF
--- a/nodeskclaw-backend/app/api/blackboard.py
+++ b/nodeskclaw-backend/app/api/blackboard.py
@@ -48,15 +48,22 @@ async def _notify_mentions(
     workspace_id: str,
     mentions: list,
     author_name: str,
-    context: str,
+    post_id: str,
+    title: str,
+    action_label: str,
     db: AsyncSession,
 ) -> None:
     from app.services import collaboration_service
     agent_ids = [m.id for m in mentions if m.type == "agent"]
     if agent_ids:
-        msg = f"{author_name} mentioned you in {context}"
+        msg = (
+            f'{author_name} mentioned you in a blackboard {action_label} '
+            f'"{title}" (post_id: {post_id}). '
+            'Reply in the blackboard thread with the nodeskclaw_blackboard tool '
+            'using action "reply_post" and this post_id. Do not reply in chat.'
+        )
         await collaboration_service.send_system_message_to_agents(
-            workspace_id, agent_ids, msg, db,
+            workspace_id, agent_ids, msg, db, mention_targets=agent_ids,
         )
 
 
@@ -90,8 +97,7 @@ async def create_post(
     _broadcast(workspace_id, "post:created", post_info.model_dump(mode="json"))
     if mentions:
         await _notify_mentions(
-            workspace_id, mentions, author_name,
-            f"a post: {data.title}", db,
+            workspace_id, mentions, author_name, post_info.id, data.title, "post", db,
         )
     return _ok(post_info.model_dump(mode="json"))
 
@@ -195,8 +201,7 @@ async def create_reply(
     })
     if mentions:
         await _notify_mentions(
-            workspace_id, mentions, author_name,
-            f"a reply on: {post.title}", db,
+            workspace_id, mentions, author_name, post_id, post.title, "reply", db,
         )
     return _ok(reply_info.model_dump(mode="json"))
 

--- a/nodeskclaw-backend/app/services/collaboration_service.py
+++ b/nodeskclaw-backend/app/services/collaboration_service.py
@@ -547,6 +547,7 @@ async def send_system_message_to_agents(
     agent_ids: list[str],
     message: str,
     db: AsyncSession,
+    mention_targets: list[str] | None = None,
 ) -> None:
     """Send a system-generated message to specific agents via the MessageBus."""
     from app.services.runtime.messaging.bus import message_bus
@@ -557,6 +558,7 @@ async def send_system_message_to_agents(
         content=message,
         source_label="system_notify",
         targets=agent_ids,
+        mention_targets=mention_targets,
     )
 
     result = await message_bus.publish(envelope, db=db)

--- a/nodeskclaw-backend/app/services/runtime/messaging/ingestion/system.py
+++ b/nodeskclaw-backend/app/services/runtime/messaging/ingestion/system.py
@@ -19,8 +19,10 @@ def build_system_envelope(
     content: str,
     source_label: str = "system",
     targets: list[str] | None = None,
+    mention_targets: list[str] | None = None,
 ) -> MessageEnvelope:
     routing_targets = targets or []
+    resolved_mention_targets = mention_targets or []
     mode = "broadcast"
     if routing_targets:
         mode = "unicast" if len(routing_targets) == 1 else "multicast"
@@ -38,6 +40,7 @@ def build_system_envelope(
             intent=IntentType.NOTIFY,
             content=content,
             priority=Priority.NORMAL,
+            extensions={"mention_targets": resolved_mention_targets},
             routing=MessageRouting(mode=mode, targets=routing_targets),
         ),
     )

--- a/nodeskclaw-backend/tests/test_blackboard_mentions.py
+++ b/nodeskclaw-backend/tests/test_blackboard_mentions.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.api.blackboard import _notify_mentions
+from app.services.runtime.messaging.ingestion.system import build_system_envelope
+
+
+@pytest.mark.asyncio
+async def test_notify_mentions_targets_agents_and_guides_reply():
+    mentions = [
+        SimpleNamespace(type="agent", id="inst-001"),
+        SimpleNamespace(type="human", id="user-001"),
+        SimpleNamespace(type="agent", id="inst-002"),
+    ]
+
+    with patch(
+        "app.services.collaboration_service.send_system_message_to_agents",
+        new_callable=AsyncMock,
+    ) as mock_send:
+        await _notify_mentions(
+            "ws-001",
+            mentions,
+            "Alice",
+            "post-001",
+            "Sprint Planning",
+            "post",
+            AsyncMock(),
+        )
+
+    mock_send.assert_awaited_once()
+    args, kwargs = mock_send.await_args
+    assert args[0] == "ws-001"
+    assert args[1] == ["inst-001", "inst-002"]
+    assert args[2] == (
+        'Alice mentioned you in a blackboard post "Sprint Planning" (post_id: post-001). '
+        'Reply in the blackboard thread with the nodeskclaw_blackboard tool '
+        'using action "reply_post" and this post_id. Do not reply in chat.'
+    )
+    assert kwargs["mention_targets"] == ["inst-001", "inst-002"]
+
+
+@pytest.mark.asyncio
+async def test_notify_mentions_skips_when_no_agent_targets():
+    mentions = [SimpleNamespace(type="human", id="user-001")]
+
+    with patch(
+        "app.services.collaboration_service.send_system_message_to_agents",
+        new_callable=AsyncMock,
+    ) as mock_send:
+        await _notify_mentions(
+            "ws-001",
+            mentions,
+            "Alice",
+            "post-001",
+            "Sprint Planning",
+            "reply",
+            AsyncMock(),
+        )
+
+    mock_send.assert_not_awaited()
+
+
+def test_build_system_envelope_keeps_mention_targets():
+    envelope = build_system_envelope(
+        workspace_id="ws-001",
+        content="hello",
+        targets=["inst-001", "inst-002"],
+        mention_targets=["inst-001", "inst-002"],
+    )
+
+    assert envelope.data is not None
+    assert envelope.data.routing.targets == ["inst-001", "inst-002"]
+    assert envelope.data.extensions["mention_targets"] == ["inst-001", "inst-002"]


### PR DESCRIPTION
## 变更说明
- 给黑板 @AI 系统通知补上 mention_targets，避免被 @ 的 AI 落到 no_reply 分支
- 在黑板 mention 通知正文里补充 reply_post 指引和 post_id
- 新增后端单测，覆盖通知定向和 system envelope 透传

## 验证
- uv run pytest tests/test_blackboard_mentions.py tests/test_tunnel_context_prompt.py
- uv run ruff check app/api/blackboard.py app/services/collaboration_service.py app/services/runtime/messaging/ingestion/system.py tests/test_blackboard_mentions.py

## 范围说明
- 这次只修复“被 @ 的 AI 会被触发并知道该回帖”
- 不包含楼层号字段和前端楼层展示调整
