### PR TITLE
fix(image): 修复升级后旧技能与记忆未迁移

### DIFF
--- a/nodeskclaw-artifacts/openclaw-image/Dockerfile
+++ b/nodeskclaw-artifacts/openclaw-image/Dockerfile
@@ -58,6 +58,7 @@ RUN mkdir -p /root/.openclaw/agents/main/sessions \
 # ---------- 配置模板 ----------
 COPY openclaw.json.template /root/.openclaw/openclaw.json.template
 COPY repair-sessions-index.js /repair-sessions-index.js
+COPY repair-user-data.js /repair-user-data.js
 
 # ---------- 版本标记 ----------
 RUN echo "${IMAGE_VERSION}" > /root/.openclaw-version

--- a/nodeskclaw-artifacts/openclaw-image/docker-entrypoint.sh
+++ b/nodeskclaw-artifacts/openclaw-image/docker-entrypoint.sh
@@ -87,14 +87,26 @@ if [ -f "${CONFIG_FILE}" ]; then
       c.gateway.controlUi.dangerouslyDisableDeviceAuth = true;
       changed = true;
     }
+    const skills = c.skills ?? (c.skills = {});
+    const load = skills.load ?? (skills.load = {});
+    const extraDirs = Array.isArray(load.extraDirs) ? load.extraDirs : [];
+    if (!extraDirs.includes('/root/.openclaw/skills')) {
+      extraDirs.push('/root/.openclaw/skills');
+      load.extraDirs = extraDirs;
+      changed = true;
+    }
     if (changed) {
       fs.writeFileSync(f, JSON.stringify(c, null, 2));
-      console.log('[entrypoint] 已补全 controlUi 配置');
+      console.log('[entrypoint] 已补全 controlUi / skills 配置');
     }
   "
 fi
 
-# ---- 1.2. 会话索引修复（兼容旧版会话文件命名） ----
+# ---- 1.2. 升级数据修复（兼容旧版目录/文件命名） ----
+
+node /repair-user-data.js
+
+# ---- 1.3. 会话索引修复（兼容旧版会话文件命名） ----
 
 if [ -d "${OPENCLAW_DIR}/agents/main/sessions" ]; then
   node /repair-sessions-index.js

--- a/nodeskclaw-artifacts/openclaw-image/repair-user-data.js
+++ b/nodeskclaw-artifacts/openclaw-image/repair-user-data.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const openclawDir = process.env.OPENCLAW_DIR || "/root/.openclaw";
+const memoryDir = path.join(openclawDir, "memory");
+const skillsDir = path.join(openclawDir, "skills");
+const legacyMemoryFile = path.join(memoryDir, "Claw_Smith_Memory.md");
+const memoryFile = path.join(memoryDir, "MEMORY.md");
+const legacySkillsDir = path.join(openclawDir, "workspace", "skills");
+
+function migrateMemory() {
+  if (!fs.existsSync(legacyMemoryFile)) {
+    return false;
+  }
+
+  if (!fs.existsSync(memoryFile)) {
+    fs.renameSync(legacyMemoryFile, memoryFile);
+    console.log("[entrypoint] 已迁移旧记忆文件到 MEMORY.md");
+    return true;
+  }
+
+  fs.rmSync(legacyMemoryFile, { force: true });
+  console.log("[entrypoint] 已清理旧记忆文件 Claw_Smith_Memory.md");
+  return true;
+}
+
+function migrateSkills() {
+  if (!fs.existsSync(legacySkillsDir) || !fs.statSync(legacySkillsDir).isDirectory()) {
+    return false;
+  }
+
+  fs.mkdirSync(skillsDir, { recursive: true });
+  let movedCount = 0;
+
+  for (const entry of fs.readdirSync(legacySkillsDir)) {
+    const from = path.join(legacySkillsDir, entry);
+    const to = path.join(skillsDir, entry);
+
+    if (fs.existsSync(to)) {
+      continue;
+    }
+
+    fs.renameSync(from, to);
+    movedCount += 1;
+  }
+
+  if (movedCount === 0) {
+    return false;
+  }
+
+  console.log(`[entrypoint] 已迁移 ${movedCount} 个旧技能目录到 /root/.openclaw/skills`);
+  return true;
+}
+
+function main() {
+  if (!fs.existsSync(openclawDir)) {
+    return;
+  }
+
+  migrateMemory();
+  migrateSkills();
+}
+
+main();


### PR DESCRIPTION
## 变更说明
- 新增启动期旧数据迁移脚本，兼容升级后遗留的 `Claw_Smith_Memory.md`
- 兼容把旧的 `workspace/skills` 技能目录迁到当前 `/root/.openclaw/skills`
- entrypoint 在配置补全时确保 `skills.load.extraDirs` 包含 `/root/.openclaw/skills`

## 验证
- 使用临时目录手工验证旧记忆文件会迁移或清理
- 使用临时目录手工验证 `workspace/skills/*` 会迁移到 `skills/*`
- 手工验证配置补全会写入 `skills.load.extraDirs`

## 关联
- 目标收口 #73
- 目标收口 #74
