### PR TITLE
fix(blackboard): 补齐帖子回复楼层号

### DIFF
--- a/nodeskclaw-backend/alembic/versions/7c6a5b4d3e2f_add_floor_number_to_blackboard_replies.py
+++ b/nodeskclaw-backend/alembic/versions/7c6a5b4d3e2f_add_floor_number_to_blackboard_replies.py
@@ -1,0 +1,66 @@
+"""add_floor_number_to_blackboard_replies
+
+Revision ID: 7c6a5b4d3e2f
+Revises: b7d2e9f31a04
+Create Date: 2026-03-27 14:55:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7c6a5b4d3e2f'
+down_revision: Union[str, Sequence[str], None] = 'b7d2e9f31a04'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'blackboard_replies',
+        sa.Column('floor_number', sa.Integer(), nullable=True),
+    )
+
+    op.execute("""
+        WITH ranked AS (
+            SELECT
+                id,
+                ROW_NUMBER() OVER (
+                    PARTITION BY post_id
+                    ORDER BY created_at, id
+                ) AS floor_number
+            FROM blackboard_replies
+            WHERE deleted_at IS NULL
+        )
+        UPDATE blackboard_replies AS replies
+        SET floor_number = ranked.floor_number
+        FROM ranked
+        WHERE replies.id = ranked.id
+    """)
+
+    op.execute("""
+        UPDATE blackboard_replies
+        SET floor_number = 1
+        WHERE floor_number IS NULL
+    """)
+
+    op.alter_column('blackboard_replies', 'floor_number', nullable=False)
+    op.create_index(
+        'uq_blackboard_reply_post_floor_active',
+        'blackboard_replies',
+        ['post_id', 'floor_number'],
+        unique=True,
+        postgresql_where=sa.text('deleted_at IS NULL'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        'uq_blackboard_reply_post_floor_active',
+        table_name='blackboard_replies',
+        postgresql_where=sa.text('deleted_at IS NULL'),
+    )
+    op.drop_column('blackboard_replies', 'floor_number')

--- a/nodeskclaw-backend/app/models/blackboard_post.py
+++ b/nodeskclaw-backend/app/models/blackboard_post.py
@@ -38,6 +38,6 @@ class BlackboardPost(BaseModel):
     replies = relationship(
         "BlackboardReply",
         back_populates="post",
-        order_by="BlackboardReply.created_at",
+        order_by="BlackboardReply.floor_number",
         lazy="selectin",
     )

--- a/nodeskclaw-backend/app/models/blackboard_reply.py
+++ b/nodeskclaw-backend/app/models/blackboard_reply.py
@@ -1,6 +1,6 @@
 """BlackboardReply — reply to a blackboard post."""
 
-from sqlalchemy import ForeignKey, String, Text
+from sqlalchemy import ForeignKey, Index, Integer, String, Text, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import BaseModel
@@ -8,10 +8,20 @@ from app.models.base import BaseModel
 
 class BlackboardReply(BaseModel):
     __tablename__ = "blackboard_replies"
+    __table_args__ = (
+        Index(
+            "uq_blackboard_reply_post_floor_active",
+            "post_id",
+            "floor_number",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )
 
     post_id: Mapped[str] = mapped_column(
         String(36), ForeignKey("blackboard_posts.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    floor_number: Mapped[int] = mapped_column(Integer, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False)
     author_type: Mapped[str] = mapped_column(String(10), nullable=False)
     author_id: Mapped[str] = mapped_column(String(36), nullable=False)

--- a/nodeskclaw-backend/app/schemas/workspace.py
+++ b/nodeskclaw-backend/app/schemas/workspace.py
@@ -241,6 +241,7 @@ class MentionInfo(BaseModel):
 class ReplyInfo(BaseModel):
     id: str
     post_id: str
+    floor_number: int
     content: str
     author_type: str
     author_id: str

--- a/nodeskclaw-backend/app/services/workspace_service.py
+++ b/nodeskclaw-backend/app/services/workspace_service.py
@@ -1249,6 +1249,7 @@ def _reply_to_info(r: BlackboardReply) -> ReplyInfo:
     return ReplyInfo(
         id=r.id,
         post_id=r.post_id,
+        floor_number=r.floor_number,
         content=r.content,
         author_type=r.author_type,
         author_id=r.author_id,
@@ -1437,8 +1438,17 @@ async def create_reply(
     if post is None:
         return None
 
+    floor_result = await db.execute(
+        select(func.max(BlackboardReply.floor_number)).where(
+            BlackboardReply.post_id == post_id,
+            BlackboardReply.deleted_at.is_(None),
+        )
+    )
+    next_floor_number = (floor_result.scalar_one_or_none() or 0) + 1
+
     reply = BlackboardReply(
         post_id=post_id,
+        floor_number=next_floor_number,
         content=data.content,
         author_type=author_type,
         author_id=author_id,

--- a/nodeskclaw-backend/tests/test_blackboard_reply_floor.py
+++ b/nodeskclaw-backend/tests/test_blackboard_reply_floor.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.blackboard_reply import BlackboardReply
+from app.schemas.workspace import ReplyCreate
+from app.services import workspace_service
+
+
+@pytest.mark.asyncio
+async def test_create_reply_assigns_next_floor_number():
+    post = SimpleNamespace(
+        id="post-001",
+        reply_count=1,
+        last_reply_at=None,
+    )
+
+    post_result = MagicMock()
+    post_result.scalar_one_or_none.return_value = post
+
+    floor_result = MagicMock()
+    floor_result.scalar_one_or_none.return_value = 3
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[post_result, floor_result])
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+
+    async def refresh_side_effect(obj):
+        if isinstance(obj, BlackboardReply):
+            obj.id = "reply-001"
+            obj.created_at = datetime(2026, 3, 27, tzinfo=timezone.utc)
+
+    db.refresh = AsyncMock(side_effect=refresh_side_effect)
+
+    reply_info, returned_post, mentions = await workspace_service.create_reply(
+        db,
+        "post-001",
+        "agent",
+        "inst-001",
+        "Alice",
+        ReplyCreate(content="hello @agent:123e4567-e89b-12d3-a456-426614174000"),
+    )
+
+    added_reply = db.add.call_args.args[0]
+    assert isinstance(added_reply, BlackboardReply)
+    assert added_reply.floor_number == 4
+    assert reply_info.floor_number == 4
+    assert returned_post is post
+    assert post.reply_count == 2
+    assert mentions[0].id == "123e4567-e89b-12d3-a456-426614174000"
+
+
+def test_reply_to_info_includes_floor_number():
+    reply = BlackboardReply(
+        id="reply-001",
+        post_id="post-001",
+        floor_number=2,
+        content="hello",
+        author_type="agent",
+        author_id="inst-001",
+        author_name="Alice",
+    )
+    reply.created_at = datetime(2026, 3, 27, tzinfo=timezone.utc)
+
+    info = workspace_service._reply_to_info(reply)
+
+    assert info.floor_number == 2
+    assert info.post_id == "post-001"

--- a/nodeskclaw-portal/src/components/blackboard/PostDetail.vue
+++ b/nodeskclaw-portal/src/components/blackboard/PostDetail.vue
@@ -16,6 +16,7 @@ interface ReplyItem {
   author_type: string
   author_id: string
   author_name: string
+  floor_number: number
   created_at: string
 }
 
@@ -133,7 +134,10 @@ watch(() => props.postId, fetchPost)
           class="pl-3 border-l-2 border-border"
         >
           <div class="flex items-center justify-between text-xs text-muted-foreground mb-1">
-            <span>{{ reply.author_name }}</span>
+            <div class="flex items-center gap-2 min-w-0">
+              <span class="shrink-0 font-medium text-foreground/80">{{ t('blackboard.replyFloor', { number: reply.floor_number }) }}</span>
+              <span class="truncate">{{ reply.author_name }}</span>
+            </div>
             <span>{{ formatTime(reply.created_at) }}</span>
           </div>
           <div class="prose prose-sm prose-invert max-w-none text-sm" v-html="renderMd(reply.content)" />

--- a/nodeskclaw-portal/src/i18n/locales/en-US.ts
+++ b/nodeskclaw-portal/src/i18n/locales/en-US.ts
@@ -466,6 +466,7 @@ const enUS = {
     postContentPlaceholder: "Post content (Markdown), use @agent:{id} to mention...",
     publish: "Publish",
     replies: "Replies",
+    replyFloor: "Floor {number}",
     replyPlaceholder: "Write a reply... (Cmd+Enter to send)",
     pin: "Pin",
     unpin: "Unpin",

--- a/nodeskclaw-portal/src/i18n/locales/zh-CN.ts
+++ b/nodeskclaw-portal/src/i18n/locales/zh-CN.ts
@@ -466,6 +466,7 @@ const zhCN = {
     postContentPlaceholder: "帖子内容（Markdown），使用 @agent:{id} 提及 AI 员工...",
     publish: "发布",
     replies: "回复",
+    replyFloor: "第 {number} 楼",
     replyPlaceholder: "写回复...（Cmd+Enter 发送）",
     pin: "置顶",
     unpin: "取消置顶",


### PR DESCRIPTION
## 变更说明
- 给 `blackboard_replies` 增加 `floor_number` 字段，并通过 migration 回填历史楼层号
- 新回复按帖子内最大楼层号递增生成，接口返回 `floor_number`
- 前端帖子详情页展示楼层号，并补充 i18n 词条

## 验证
- uv run pytest tests/test_blackboard_reply_floor.py tests/test_blackboard_mentions.py tests/test_tunnel_context_prompt.py
- uv run ruff check app/models/blackboard_reply.py app/models/blackboard_post.py app/schemas/workspace.py app/services/workspace_service.py tests/test_blackboard_reply_floor.py
- npm run build

## 关联
- 关闭 #46 剩余的楼层号缺口
