### PR TITLE
fix(chat): 支持清空办公室主会话历史

### DIFF
--- a/nodeskclaw-backend/app/api/workspaces.py
+++ b/nodeskclaw-backend/app/api/workspaces.py
@@ -955,6 +955,68 @@ class SystemMessageRequest(BaseModel):
     content: str
 
 
+@router.post("/{workspace_id}/messages/clear")
+async def clear_workspace_messages(
+    workspace_id: str,
+    db: AsyncSession = Depends(get_db),
+    user=Depends(_get_current_user_dep()),
+):
+    await wm_service.check_workspace_access(workspace_id, user, "manage_settings", db)
+
+    cleared_count = await msg_service.clear_workspace_messages(db, workspace_id)
+
+    repaired_instances: list[str] = []
+    restart_failures: list[str] = []
+
+    result = await db.execute(
+        sa_select(Instance)
+        .join(
+            WorkspaceAgent,
+            (WorkspaceAgent.instance_id == Instance.id) & (WorkspaceAgent.deleted_at.is_(None)),
+        )
+        .where(
+            WorkspaceAgent.workspace_id == workspace_id,
+            Instance.deleted_at.is_(None),
+            Instance.runtime == "openclaw",
+        )
+    )
+    instances = list(result.scalars().all())
+
+    if instances:
+        from app.services.llm_config_service import restart_runtime
+        from app.services.nfs_mount import remote_fs
+        from app.services.openclaw_session import clear_main_session
+
+        for instance in instances:
+            try:
+                async with remote_fs(instance, db) as fs:
+                    await clear_main_session(fs)
+                repaired_instances.append(instance.id)
+            except Exception:
+                logger.warning("clear_workspace_messages: failed to clear session for %s", instance.id, exc_info=True)
+                restart_failures.append(instance.id)
+                continue
+
+            try:
+                restart_result = await restart_runtime(instance, db)
+                if restart_result.get("status") != "ok":
+                    restart_failures.append(instance.id)
+            except Exception:
+                logger.warning("clear_workspace_messages: failed to restart runtime for %s", instance.id, exc_info=True)
+                restart_failures.append(instance.id)
+
+    broadcast_event(workspace_id, "chat:cleared", {
+        "cleared_count": cleared_count,
+        "repaired_instances": repaired_instances,
+        "restart_failures": restart_failures,
+    })
+    return _ok({
+        "cleared_count": cleared_count,
+        "repaired_instances": repaired_instances,
+        "restart_failures": restart_failures,
+    })
+
+
 @router.post("/{workspace_id}/system-message")
 async def post_system_message(
     workspace_id: str,

--- a/nodeskclaw-backend/app/services/openclaw_session.py
+++ b/nodeskclaw-backend/app/services/openclaw_session.py
@@ -19,6 +19,9 @@ OPENCLAW_CONFIG_REL = ".openclaw/openclaw.json"
 SKILLS_EXTRA_DIR = "/root/.openclaw/skills"
 
 _SESSIONS_REL = ".openclaw/agents/main/sessions/sessions.json"
+_MAIN_SESSION_KEY = "agent:main:main"
+_MAIN_SESSION_REL = ".openclaw/agents/main/sessions/agent_main_main.jsonl"
+_MAIN_SESSION_FILE = "/root/.openclaw/agents/main/sessions/agent_main_main.jsonl"
 
 
 async def _write_sessions_json(fs: RemoteFS, path: str, store: dict) -> None:
@@ -44,6 +47,47 @@ async def invalidate_skill_snapshots(fs: RemoteFS) -> None:
             logger.info("Cleared stale skillsSnapshot from %d session(s)", len(store))
     except Exception as e:
         logger.warning("Failed to invalidate skill snapshots: %s", e)
+
+
+async def clear_main_session(fs: RemoteFS) -> bool:
+    raw = await fs.read_text(_SESSIONS_REL)
+    store: dict = {}
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                store = parsed
+        except Exception as e:
+            logger.warning("Failed to parse sessions.json while clearing main session: %s", e)
+
+    main_entry: dict = {}
+    stale_keys: list[str] = []
+    for key, entry in store.items():
+        if not isinstance(entry, dict):
+            continue
+        session_id = entry.get("sessionId")
+        session_file = entry.get("sessionFile")
+        is_main = (
+            key in {"main", _MAIN_SESSION_KEY}
+            or session_id in {"main", "agent_main_main"}
+            or session_file == _MAIN_SESSION_FILE
+        )
+        if is_main:
+            main_entry = {**entry}
+            stale_keys.append(key)
+
+    for key in stale_keys:
+        store.pop(key, None)
+
+    store[_MAIN_SESSION_KEY] = {
+        **main_entry,
+        "sessionId": "agent_main_main",
+        "sessionFile": _MAIN_SESSION_FILE,
+        "systemSent": False,
+    }
+    await _write_sessions_json(fs, _SESSIONS_REL, store)
+    await fs.write_text(_MAIN_SESSION_REL, "")
+    return True
 
 
 async def inject_evolution_notification(

--- a/nodeskclaw-backend/app/services/workspace_message_service.py
+++ b/nodeskclaw-backend/app/services/workspace_message_service.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.workspace_message import WorkspaceMessage
@@ -108,6 +108,22 @@ async def get_agent_collaboration_messages(
     messages = list(result.scalars().all())
     messages.reverse()
     return messages
+
+
+async def clear_workspace_messages(
+    db: AsyncSession,
+    workspace_id: str,
+) -> int:
+    result = await db.execute(
+        update(WorkspaceMessage)
+        .where(
+            WorkspaceMessage.workspace_id == workspace_id,
+            WorkspaceMessage.deleted_at.is_(None),
+        )
+        .values(deleted_at=func.now())
+    )
+    await db.commit()
+    return result.rowcount or 0
 
 
 def build_context_prompt(

--- a/nodeskclaw-backend/tests/test_openclaw_session_clear.py
+++ b/nodeskclaw-backend/tests/test_openclaw_session_clear.py
@@ -1,0 +1,45 @@
+import json
+
+import pytest
+
+from app.services.openclaw_session import clear_main_session
+
+
+class FakeFS:
+    def __init__(self, files: dict[str, str] | None = None):
+        self.files = files or {}
+
+    async def read_text(self, path: str):
+        return self.files.get(path)
+
+    async def write_text(self, path: str, content: str) -> None:
+        self.files[path] = content
+
+
+@pytest.mark.asyncio
+async def test_clear_main_session_resets_store_and_file():
+    sessions_path = ".openclaw/agents/main/sessions/sessions.json"
+    session_file = ".openclaw/agents/main/sessions/agent_main_main.jsonl"
+    fs = FakeFS({
+        sessions_path: json.dumps({
+            "main": {
+                "sessionId": "main",
+                "sessionFile": "/root/.openclaw/agents/main/sessions/agent_main_main.jsonl",
+                "model": "gpt-5",
+            },
+            "agent:main:desk-1": {
+                "sessionId": "agent_main_desk-1",
+                "sessionFile": "/root/.openclaw/agents/main/sessions/agent_main_desk-1.jsonl",
+            },
+        }),
+        session_file: '{"type":"message"}\n',
+    })
+
+    await clear_main_session(fs)
+
+    store = json.loads(fs.files[sessions_path])
+    assert "main" not in store
+    assert store["agent:main:main"]["sessionId"] == "agent_main_main"
+    assert store["agent:main:main"]["sessionFile"] == "/root/.openclaw/agents/main/sessions/agent_main_main.jsonl"
+    assert store["agent:main:main"]["model"] == "gpt-5"
+    assert fs.files[session_file] == ""

--- a/nodeskclaw-portal/src/components/chat/ChatPanel.vue
+++ b/nodeskclaw-portal/src/components/chat/ChatPanel.vue
@@ -232,17 +232,26 @@ function insertSystemMessage(content: string, persist = true) {
   scrollToBottom()
 }
 
-function executeSlashCommand(name: string, arg?: string) {
+async function executeSlashCommand(name: string, arg?: string) {
   switch (name) {
     case 'status': {
       const lines = agents.value.map(a => `${agentLabel(a)}: ${a.status}`)
       insertSystemMessage(lines.length ? lines.join('\n') : t('chat.noAgentsInWorkspace'))
       break
     }
-    case 'clear':
-      store.chatMessages.splice(0, store.chatMessages.length)
-      insertSystemMessage(t('chat.chatCleared'), false)
+    case 'clear': {
+      if (!store.hasPermission('manage_settings')) {
+        insertSystemMessage(t('chat.clearNotAllowed'))
+        break
+      }
+      try {
+        await store.clearChatHistory(props.workspaceId)
+        insertSystemMessage(t('chat.chatCleared'), false)
+      } catch (e: any) {
+        insertSystemMessage(t('chat.clearFailed', { error: resolveApiErrorMessage(e, e?.message || '') }))
+      }
       break
+    }
     case 'restart':
       if (arg) doRestartAgent(arg)
       else insertSystemMessage(t('chat.restartUsage'))
@@ -331,7 +340,7 @@ async function sendMessage() {
       const mentionedAgent = mentions.length > 0
         ? agents.value.find(a => a.instance_id === mentions[0])
         : undefined
-      executeSlashCommand(cmdName, mentionedAgent ? agentLabel(mentionedAgent) : undefined)
+      void executeSlashCommand(cmdName, mentionedAgent ? agentLabel(mentionedAgent) : undefined)
     }
     return
   }
@@ -340,7 +349,7 @@ async function sendMessage() {
   if (slashMatch) {
     const cmd = slashMatch[1].toLowerCase()
     const arg = text.slice(slashMatch[0].length).trim().replace(/^@/, '')
-    executeSlashCommand(cmd, arg || undefined)
+    void executeSlashCommand(cmd, arg || undefined)
     return
   }
 
@@ -494,7 +503,9 @@ const editor = useEditor({
         command: ({ editor: ed, range, props: p }: any) => {
           if (p.immediate) {
             ed.chain().focus().deleteRange(range).run()
-            nextTick(() => executeSlashCommand(p.id))
+            nextTick(() => {
+              void executeSlashCommand(p.id)
+            })
             return
           }
           if (p.needsAgent) {

--- a/nodeskclaw-portal/src/i18n/locales/en-US.ts
+++ b/nodeskclaw-portal/src/i18n/locales/en-US.ts
@@ -528,6 +528,8 @@ const enUS = {
     cmdRemoveLabel: "Remove AI Employee",
     noAgentsInWorkspace: "No AI Employees in this cyber office",
     chatCleared: "Chat history cleared",
+    clearNotAllowed: "Only workspace administrators can clear chat history",
+    clearFailed: "Failed to clear chat history: {error}",
     restartUsage: "Usage: /restart {'@'}AgentName",
     removeUsage: "Usage: /remove {'@'}AgentName",
     unknownCommand: "Unknown command: /{command}",

--- a/nodeskclaw-portal/src/i18n/locales/zh-CN.ts
+++ b/nodeskclaw-portal/src/i18n/locales/zh-CN.ts
@@ -528,6 +528,8 @@ const zhCN = {
     cmdRemoveLabel: "移除 AI 员工",
     noAgentsInWorkspace: "办公室内没有 AI 员工",
     chatCleared: "聊天记录已清空",
+    clearNotAllowed: "只有办公室管理员可以清空聊天历史",
+    clearFailed: "清空聊天历史失败：{error}",
     restartUsage: "用法: /restart {'@'}AI员工名称",
     removeUsage: "用法: /remove {'@'}AI员工名称",
     unknownCommand: "未知命令: /{command}",

--- a/nodeskclaw-portal/src/stores/workspace.ts
+++ b/nodeskclaw-portal/src/stores/workspace.ts
@@ -601,6 +601,13 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     }
   }
 
+  async function clearChatHistory(workspaceId: string) {
+    await api.post(`/workspaces/${workspaceId}/messages/clear`)
+    chatMessages.value = []
+    typingAgents.value.clear()
+    unreadCount.value = 0
+  }
+
   const _typingTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
   function _handleAgentTyping(data: Record<string, unknown>) {
@@ -922,6 +929,16 @@ export const useWorkspaceStore = defineStore('workspace', () => {
             })
           }
         }
+      } catch { /* ignore */ }
+    })
+
+    eventSource.addEventListener('chat:cleared', (e: MessageEvent) => {
+      try {
+        const data = JSON.parse(e.data)
+        externalCallback?.('chat:cleared', data)
+        chatMessages.value = []
+        typingAgents.value.clear()
+        unreadCount.value = 0
       } catch { /* ignore */ }
     })
 
@@ -1324,6 +1341,7 @@ export const useWorkspaceStore = defineStore('workspace', () => {
     fetchChatHistory,
     sendWorkspaceMessage,
     sendSystemMessage,
+    clearChatHistory,
     connectSSE,
     disconnectSSE,
     sendMessage,


### PR DESCRIPTION
## 变更说明
- 新增 `POST /workspaces/{workspace_id}/messages/clear`，真正清空办公室聊天历史
- 清空时会逻辑删除 `workspace_messages`，并重置 OpenClaw `main` session 文件与 `sessions.json`
- 清空后会尝试重启办公室内的 OpenClaw runtime，确保新会话从空上下文开始
- 前端 `/clear` 改为调用后端接口，并通过 SSE `chat:cleared` 同步清空本地界面

## 验证
- uv run pytest tests/test_openclaw_session_clear.py tests/test_blackboard_reply_floor.py tests/test_blackboard_mentions.py tests/test_tunnel_context_prompt.py
- uv run ruff check app/services/workspace_message_service.py app/services/openclaw_session.py app/api/workspaces.py tests/test_openclaw_session_clear.py
- npm run build

## 范围说明
- 仅办公室管理员可执行 `/clear`
- 当前只重置 `runtime == openclaw` 的主会话

## 关联
- 目标收口 #81
