### PR TITLE
chore(zeroclaw): 升级 ZeroClaw 至 v0.6.5

### DIFF
--- a/nodeskclaw-artifacts/zeroclaw-image/Dockerfile
+++ b/nodeskclaw-artifacts/zeroclaw-image/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm-slim
 
-ARG ZEROCLAW_VERSION=v0.6.2
-ARG IMAGE_VERSION=v0.6.2
+ARG ZEROCLAW_VERSION=v0.6.5
+ARG IMAGE_VERSION=v0.6.5
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl python3-minimal python3-pip && \


### PR DESCRIPTION
## ZeroClaw 版本更新

| 项目 | 值 |
|------|-----|
| 当前版本 | `v0.6.2` |
| 最新版本 | `v0.6.5` |
| Release | https://github.com/zeroclaw-labs/zeroclaw/releases/tag/v0.6.5 |

---

**此 PR 由 GitHub Actions 自动创建。**

合并后请在云平台持续交付流水线中触发镜像构建，或本地执行 `./build.sh <engine> --version <ver>` 构建并推送新镜像。