### PR TITLE
fix(channel): 修复 tunnel 模型映射到本地 Gateway 支持的模型

### DIFF
--- a/openclaw-channel-nodeskclaw/src/tunnel-client.ts
+++ b/openclaw-channel-nodeskclaw/src/tunnel-client.ts
@@ -43,23 +43,31 @@ function deriveTunnelUrl(apiUrl: string): string {
   return `${wsUrl}/tunnel/connect`;
 }
 
+const LOCAL_GATEWAY_MODELS = ["openclaw", "openclaw/default", "openclaw/main"];
+
 function deriveDefaultChatModel(cfg: OpenClawConfig): string {
   const agents = (cfg as Record<string, unknown>).agents as Record<string, unknown> | undefined;
   const defaults = agents?.defaults as Record<string, unknown> | undefined;
   const model = defaults?.model;
 
+  let modelName = "";
   if (typeof model === "string" && model.trim()) {
-    return model.trim();
-  }
-
-  if (model && typeof model === "object") {
+    modelName = model.trim();
+  } else if (model && typeof model === "object") {
     const primary = (model as Record<string, unknown>).primary;
     if (typeof primary === "string" && primary.trim()) {
-      return primary.trim();
+      modelName = primary.trim();
     }
   }
 
-  return process.env.OPENCLAW_DEFAULT_MODEL || "gpt-4";
+  // If model contains "/" it's provider/model format (e.g. "minimax-anthropic/MiniMax-M2.7")
+  // which is not valid for local OpenClaw Gateway - map to openclaw/main
+  if (modelName && (!LOCAL_GATEWAY_MODELS.includes(modelName))) {
+    console.log("[tunnel] Model '%s' not in local gateway models, using 'openclaw/main'", modelName);
+    return "openclaw/main";
+  }
+
+  return modelName || process.env.OPENCLAW_DEFAULT_MODEL || "openclaw/main";
 }
 
 export function startTunnelClient(cfg: OpenClawConfig, callbacks?: TunnelCallbacks): TunnelClient {


### PR DESCRIPTION
## 变更说明
- 将实例默认模型读取结果限制到本地 OpenClaw Gateway 支持的模型集合
- 当配置为  形式时回退到 
- 默认兜底值同步改为 

## 验证
- 代码级自审
- 该包当前无独立 build/test 脚本

## 说明
- 本 PR 保留社区贡献者原始 Author，内容来自 #121 的 cherry-pick