### PR TITLE
fix(docker-compose): 修复 Linux 环境下 host.docker.internal 无法解析

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,14 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - type: bind
         source: /var/run/docker.sock
         target: /var/run/docker.sock
       - type: bind
-        source: ${NODESKCLAW_DATA_DIR:-${HOME:-.}/.nodeskclaw/docker-instances}
+        source: ${DOCKER_HOST_DATA_DIR}
         target: /nodeskclaw-data
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://nodeskclaw:nodeskclaw@postgres:5432/nodeskclaw}
@@ -37,7 +39,7 @@ services:
       LLM_PROXY_INTERNAL_URL: http://llm-proxy:8080
       NODESKCLAW_EDITION: ce
       DOCKER_DATA_DIR: /nodeskclaw-data
-      DOCKER_HOST_DATA_DIR: ${NODESKCLAW_DATA_DIR:-${HOME:-.}/.nodeskclaw/docker-instances}
+      DOCKER_HOST_DATA_DIR: ${DOCKER_HOST_DATA_DIR}
       # AI 员工回连后端地址（仅管理 Docker 实例时可保持默认 localhost）
       # 若管理远端 K8s 集群上的 AI 员工，必须改为 K8s Pod 可达的外部地址
       AGENT_API_BASE_URL: ${AGENT_API_BASE_URL:-http://localhost:4510/api/v1}


### PR DESCRIPTION
## Summary

- 添加 `extra_hosts` 配置，将 `host.docker.internal` 映射到 `host-gateway`，解决 Linux 上 Docker 无法解析 `host.docker.internal` 的问题
- 简化嵌套变量语法：docker-compose v1 不支持 `${VAR1:-${VAR2:-.}}` 嵌套默认值，改为直接引用 `DOCKER_HOST_DATA_DIR`，由 `.env` 提供绝对路径

## Test plan

- [x] 在 Linux 环境下验证 Docker 实例健康检查正常（`http://host.docker.internal:13000/healthz` 可达）
- [x] 验证 portal 页面实例状态显示正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)