### PR TITLE
fix(genes): 收紧学习回调鉴权校验

### DIFF
--- a/nodeskclaw-backend/app/api/genes.py
+++ b/nodeskclaw-backend/app/api/genes.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_db
+from app.core.exceptions import BadRequestError
 from app.core.security import get_current_user
 from app.models.user import User
 from app.schemas.common import ApiResponse, PaginatedResponse, Pagination
@@ -298,8 +299,14 @@ async def create_gene_from_agent(
 @router.post("/genes/learning-callback")
 async def learning_callback(
     payload: LearningCallbackPayload,
+    sig: str = Query(...),
+    instance_id: str = Query(...),
     db: AsyncSession = Depends(get_db),
 ):
+    if payload.instance_id != instance_id:
+        raise BadRequestError("回调实例与签名参数不匹配")
+    if not gene_service.verify_gene_callback_signature(payload, "learn", sig):
+        raise BadRequestError("回调签名无效")
     result = await gene_service.handle_learning_callback(db, payload)
     return ApiResponse(data=result)
 
@@ -307,8 +314,14 @@ async def learning_callback(
 @router.post("/genes/creation-callback")
 async def creation_callback(
     payload: LearningCallbackPayload,
+    sig: str = Query(...),
+    instance_id: str = Query(...),
     db: AsyncSession = Depends(get_db),
 ):
+    if payload.instance_id != instance_id:
+        raise BadRequestError("回调实例与签名参数不匹配")
+    if not gene_service.verify_gene_callback_signature(payload, "create", sig):
+        raise BadRequestError("回调签名无效")
     result = await gene_service.handle_creation_callback(db, payload)
     return ApiResponse(data=result)
 
@@ -316,8 +329,14 @@ async def creation_callback(
 @router.post("/genes/forgetting-callback")
 async def forgetting_callback(
     payload: LearningCallbackPayload,
+    sig: str = Query(...),
+    instance_id: str = Query(...),
     db: AsyncSession = Depends(get_db),
 ):
+    if payload.instance_id != instance_id:
+        raise BadRequestError("回调实例与签名参数不匹配")
+    if not gene_service.verify_gene_callback_signature(payload, "forget", sig):
+        raise BadRequestError("回调签名无效")
     result = await gene_service.handle_forgetting_callback(db, payload)
     return ApiResponse(data=result)
 

--- a/nodeskclaw-backend/app/core/config.py
+++ b/nodeskclaw-backend/app/core/config.py
@@ -104,6 +104,7 @@ class Settings(BaseSettings):
 
     # ── Agent API（AI 员工 Pod 回调后端的内网地址）────────
     AGENT_API_BASE_URL: str = "http://localhost:4510/api/v1"
+    GENE_CALLBACK_SECRET: str = ""
 
     # ── Agent Tunnel（实例通过 WebSocket 主动连接后端的地址）────
     TUNNEL_BASE_URL: str = ""

--- a/nodeskclaw-backend/app/services/gene_service.py
+++ b/nodeskclaw-backend/app/services/gene_service.py
@@ -1,15 +1,19 @@
 """Gene Evolution Ecosystem service: CRUD, install/learn engine, rating, evolution."""
 
 import asyncio
+import hashlib
+import hmac
 import json
 import logging
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Coroutine
+from urllib.parse import urlencode
 
 from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.exceptions import AppException, BadRequestError, ConflictError, NotFoundError
 from app.models.base import not_deleted
 from app.models.corridor import HumanHex
@@ -109,6 +113,32 @@ def _json_dumps(obj) -> str | None:
     if obj is None:
         return None
     return json.dumps(obj, ensure_ascii=False)
+
+
+def _gene_callback_secret() -> str:
+    return settings.GENE_CALLBACK_SECRET or settings.JWT_SECRET
+
+
+def sign_gene_callback(task_id: str, instance_id: str, mode: str) -> str:
+    payload = f"{task_id}:{instance_id}:{mode}"
+    return hmac.new(
+        _gene_callback_secret().encode(),
+        payload.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def verify_gene_callback_signature(payload: LearningCallbackPayload, mode: str, sig: str) -> bool:
+    expected = sign_gene_callback(payload.task_id, payload.instance_id, mode)
+    return hmac.compare_digest(expected, sig)
+
+
+def build_gene_callback_url(base_url: str, path: str, task_id: str, instance_id: str, mode: str) -> str:
+    params = urlencode({
+        "instance_id": instance_id,
+        "sig": sign_gene_callback(task_id, instance_id, mode),
+    })
+    return f"{base_url}{path}?{params}"
 
 
 def _truncate_text(text: str, limit: int = 120) -> str:
@@ -1341,10 +1371,14 @@ async def _send_learning_task(
         skill = manifest.get("skill", {})
         learning = manifest.get("learning")
 
-        from app.core.config import settings
-
-        callback_base = getattr(settings, "NODESKCLAW_WEBHOOK_BASE_URL", "") or ""
-        callback_url = f"{callback_base}/api/v1/genes/learning-callback"
+        callback_base = settings.NODESKCLAW_WEBHOOK_BASE_URL or ""
+        callback_url = build_gene_callback_url(
+            callback_base,
+            "/api/v1/genes/learning-callback",
+            ig.id,
+            instance.id,
+            "learn",
+        )
 
         gene_content = skill.get("content", "")
         force_deep = not _has_frontmatter(gene_content)
@@ -1442,6 +1476,8 @@ async def handle_learning_callback(
     ig_obj = ig.scalar_one_or_none()
     if not ig_obj:
         raise NotFoundError(f"学习任务 '{payload.task_id}' 不存在")
+    if ig_obj.instance_id != payload.instance_id:
+        raise BadRequestError("回调实例与学习任务不匹配")
 
     instance = await get_instance(ig_obj.instance_id, db)
     gene = await db.execute(
@@ -1933,15 +1969,18 @@ async def trigger_gene_creation(
     from app.services.instance_service import get_instance
 
     instance = await get_instance(instance_id, db)
-
-    from app.core.config import settings
-
-    callback_base = getattr(settings, "NODESKCLAW_WEBHOOK_BASE_URL", "") or ""
-    callback_url = f"{callback_base}/api/v1/genes/creation-callback"
-
     import uuid
 
     task_id = str(uuid.uuid4())
+
+    callback_base = settings.NODESKCLAW_WEBHOOK_BASE_URL or ""
+    callback_url = build_gene_callback_url(
+        callback_base,
+        "/api/v1/genes/creation-callback",
+        task_id,
+        instance.id,
+        "create",
+    )
 
     payload = {
         "mode": "create",
@@ -1980,6 +2019,8 @@ async def handle_creation_callback(
         )
     )
     instance = instance_result.scalar_one_or_none()
+    if instance is None:
+        raise NotFoundError("实例不存在")
 
     gene_desc = meta.get("gene_description", "")
     gene_short_desc = gene_desc[:256] if gene_desc else None
@@ -2016,13 +2057,27 @@ async def handle_creation_callback(
             "gene_name": gene.name,
         })
 
-    _fire_task(_push_created_gene_to_registry(gene_manifest, gene.slug, gene.name, gene_desc, meta))
+    _fire_task(
+        _push_created_gene_to_registry(
+            gene_manifest,
+            gene.slug,
+            gene.name,
+            gene_desc,
+            meta,
+            instance.runtime,
+        )
+    )
 
     return {"status": "created", "gene_id": gene.id, "slug": gene.slug}
 
 
 async def _push_created_gene_to_registry(
-    manifest: dict, slug: str, name: str, description: str, meta: dict,
+    manifest: dict,
+    slug: str,
+    name: str,
+    description: str,
+    meta: dict,
+    runtime: str,
 ) -> None:
     """Best-effort push of an Agent-created gene to default registry."""
     full_manifest = {
@@ -2035,7 +2090,7 @@ async def _push_created_gene_to_registry(
         "tags": meta.get("suggested_tags", []),
         "icon": meta.get("icon"),
         "author": {"type": "agent", "name": "nodeskclaw"},
-        "compatibility": [{"product": instance.runtime if instance else "openclaw", "min_version": "1.0.0"}],
+        "compatibility": [{"product": runtime or "openclaw", "min_version": "1.0.0"}],
         **manifest,
     }
     aggregator = get_aggregator()
@@ -2264,10 +2319,14 @@ async def _send_forgetting_task(
         manifest = _json_loads(gene.manifest) or {}
         skill_content = manifest.get("skill", {}).get("content", "")
 
-        from app.core.config import settings
-
-        callback_base = getattr(settings, "NODESKCLAW_WEBHOOK_BASE_URL", "") or ""
-        callback_url = f"{callback_base}/api/v1/genes/forgetting-callback"
+        callback_base = settings.NODESKCLAW_WEBHOOK_BASE_URL or ""
+        callback_url = build_gene_callback_url(
+            callback_base,
+            "/api/v1/genes/forgetting-callback",
+            ig.id,
+            instance.id,
+            "forget",
+        )
 
         payload = {
             "mode": "forget",
@@ -2306,6 +2365,8 @@ async def handle_forgetting_callback(
     ig = await db.get(InstanceGene, payload.task_id)
     if not ig:
         raise NotFoundError(f"InstanceGene not found: {payload.task_id}")
+    if ig.instance_id != payload.instance_id:
+        raise BadRequestError("回调实例与遗忘任务不匹配")
 
     instance = await get_instance(ig.instance_id, db)
     gene_result = await db.execute(

--- a/nodeskclaw-backend/tests/test_gene_callback_signature.py
+++ b/nodeskclaw-backend/tests/test_gene_callback_signature.py
@@ -1,0 +1,33 @@
+from app.schemas.gene import LearningCallbackPayload
+from app.services.gene_service import (
+    build_gene_callback_url,
+    sign_gene_callback,
+    verify_gene_callback_signature,
+)
+
+
+def test_sign_and_verify_gene_callback_signature():
+    payload = LearningCallbackPayload(
+        task_id="task-1",
+        instance_id="inst-1",
+        mode="learn",
+        decision="learned",
+    )
+
+    sig = sign_gene_callback(payload.task_id, payload.instance_id, "learn")
+
+    assert verify_gene_callback_signature(payload, "learn", sig) is True
+    assert verify_gene_callback_signature(payload, "forget", sig) is False
+
+
+def test_build_gene_callback_url_includes_signature_and_instance():
+    url = build_gene_callback_url(
+        "https://example.com",
+        "/api/v1/genes/learning-callback",
+        "task-1",
+        "inst-1",
+        "learn",
+    )
+
+    assert "instance_id=inst-1" in url
+    assert "sig=" in url


### PR DESCRIPTION
## Summary

- 为 learning / creation / forgetting callback URL 增加签名参数
- 在 callback API 入口校验签名与 `instance_id`
- 在 service 侧补任务归属校验，拒绝任务与实例不匹配的回调
- 补充签名构造与校验的回归测试

## Root Cause

- 基因 callback 入口原本是公开写接口，没有任何鉴权或签名校验
- learning / forgetting 回调只按 `task_id` 查任务，没有确认 payload 里的 `instance_id` 是否匹配
- creation 回调也没有确认目标实例存在

## Impact

- 未携带合法签名的请求不能再进入回调处理逻辑
- 学习和遗忘回调不能再跨实例伪造任务结果
- creation 回调不能再对不存在实例落基因记录

## Validation

- `cd nodeskclaw-backend && uv run pytest tests/test_gene_callback_signature.py`
- `cd nodeskclaw-backend && uv run ruff check app/api/genes.py app/services/gene_service.py tests/test_gene_callback_signature.py`

Closes #142
