### PR TITLE
fix(instances): 收紧管理端实例组织边界

### DIFF
--- a/nodeskclaw-backend/app/api/instances.py
+++ b/nodeskclaw-backend/app/api/instances.py
@@ -10,7 +10,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core import hooks
-from app.core.deps import get_db
+from app.core.deps import get_current_org, get_db
 from app.core.exceptions import NotFoundError
 from app.core.security import get_current_user
 from app.models.cluster import Cluster
@@ -93,10 +93,11 @@ async def list_instances(
 async def get_instance(
     instance_id: str,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """实例详情（含 Pod 实时信息）。"""
-    data = await instance_service.get_instance_detail(instance_id, db)
+    _current_user, org = org_ctx
+    data = await instance_service.get_instance_detail(instance_id, db, org.id)
     return ApiResponse(data=data)
 
 
@@ -105,10 +106,11 @@ async def delete_instance(
     instance_id: str,
     delete_k8s: bool = Query(True),
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """删除实例。"""
-    await instance_service.delete_instance(instance_id, db, delete_k8s)
+    _current_user, org = org_ctx
+    await instance_service.delete_instance(instance_id, db, delete_k8s, org.id)
     await hooks.emit("operation_audit", action="instance.deleted", target_type="instance", target_id=instance_id, actor_id=_current_user.id, org_id=_current_user.current_org_id, details={"delete_k8s": delete_k8s, "source": "admin"})
     return ApiResponse(message="实例已删除")
 
@@ -122,10 +124,11 @@ async def scale_instance(
     instance_id: str,
     body: ScaleBody,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """扩缩容。"""
-    await instance_service.scale_instance(instance_id, body.replicas, db)
+    _current_user, org = org_ctx
+    await instance_service.scale_instance(instance_id, body.replicas, db, org.id)
     await hooks.emit("operation_audit", action="instance.scaled", target_type="instance", target_id=instance_id, actor_id=_current_user.id, org_id=_current_user.current_org_id, details={"replicas": body.replicas, "source": "admin"})
     return ApiResponse(message=f"已扩缩容至 {body.replicas} 副本")
 
@@ -134,11 +137,12 @@ async def scale_instance(
 async def restart_instance(
     instance_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """重启实例（scale 0 -> scale N）。"""
+    current_user, org = org_ctx
     logger.info("用户 %s (%s) 请求重启实例 %s", current_user.name, current_user.id, instance_id)
-    await instance_service.restart_instance(instance_id, db)
+    await instance_service.restart_instance(instance_id, db, org.id)
     await hooks.emit("operation_audit", action="instance.restart", target_type="instance", target_id=instance_id, actor_id=current_user.id, org_id=current_user.current_org_id, details={"source": "admin"})
     return ApiResponse(message="已触发重启，实例将在数秒后恢复")
 
@@ -147,10 +151,11 @@ async def restart_instance(
 async def deploy_history(
     instance_id: str,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """部署历史。"""
-    data = await instance_service.get_deploy_history(instance_id, db)
+    _current_user, org = org_ctx
+    data = await instance_service.get_deploy_history(instance_id, db, org.id)
     return ApiResponse(data=data)
 
 
@@ -159,10 +164,11 @@ async def save_config(
     instance_id: str,
     body: UpdateConfigRequest,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """保存实例配置变更到 pending_config（不立即生效）。"""
-    data = await instance_service.save_config(instance_id, body, db)
+    _current_user, org = org_ctx
+    data = await instance_service.save_config(instance_id, body, db, org.id)
     await hooks.emit("operation_audit", action="instance.config_saved", target_type="instance", target_id=instance_id, actor_id=_current_user.id, org_id=_current_user.current_org_id, details={"source": "admin"})
     return ApiResponse(data=data)
 
@@ -171,10 +177,11 @@ async def save_config(
 async def apply_config(
     instance_id: str,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """将 pending_config 应用到 K8s，触发滚动更新。"""
-    data = await instance_service.apply_config(instance_id, current_user.id, db)
+    current_user, org = org_ctx
+    data = await instance_service.apply_config(instance_id, current_user.id, db, org.id)
     await hooks.emit("operation_audit", action="instance.config_applied", target_type="instance", target_id=instance_id, actor_id=current_user.id, org_id=current_user.current_org_id, details={"source": "admin"})
     return ApiResponse(data=data)
 
@@ -188,11 +195,12 @@ async def rollback_instance(
     instance_id: str,
     body: RollbackBody,
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """回滚到指定版本。"""
+    current_user, org = org_ctx
     data = await instance_service.rollback_instance(
-        instance_id, body.target_revision, current_user.id, db
+        instance_id, body.target_revision, current_user.id, db, org.id
     )
     await hooks.emit("operation_audit", action="instance.rolled_back", target_type="instance", target_id=instance_id, actor_id=current_user.id, org_id=current_user.current_org_id, details={"target_revision": body.target_revision, "source": "admin"})
     return ApiResponse(data=data)
@@ -202,10 +210,11 @@ async def rollback_instance(
 async def sync_token(
     instance_id: str,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """从运行中的 Pod 获取 Gateway Token 并回填到 DB。"""
-    token = await instance_service.sync_gateway_token(instance_id, db)
+    _current_user, org = org_ctx
+    token = await instance_service.sync_gateway_token(instance_id, db, org.id)
     await hooks.emit("operation_audit", action="instance.token_synced", target_type="instance", target_id=instance_id, actor_id=_current_user.id, org_id=_current_user.current_org_id, details={"source": "admin"})
     return ApiResponse(data={"token": token})
 
@@ -217,10 +226,11 @@ async def pod_logs(
     container: str | None = Query(None),
     tail_lines: int = Query(200),
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """获取 Pod 日志。"""
-    data = await instance_service.get_pod_logs(instance_id, pod_name, db, container, tail_lines)
+    _current_user, org = org_ctx
+    data = await instance_service.get_pod_logs(instance_id, pod_name, db, container, tail_lines, org.id)
     return ApiResponse(data=data)
 
 
@@ -232,13 +242,14 @@ async def pod_logs_stream(
     tail_lines: int = Query(50),
     since_seconds: int | None = Query(None, description="最近 N 秒的日志"),
     since_time: str | None = Query(None, description="ISO 8601 起始时间"),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """SSE 流: 实时 Pod 日志，支持时间范围筛选。"""
     from app.core.deps import async_session_factory
 
+    _current_user, org = org_ctx
     async with async_session_factory() as db:
-        instance = await instance_service.get_instance(instance_id, db)
+        instance = await instance_service.get_instance(instance_id, db, org.id)
         result = await db.execute(
             select(Cluster).where(Cluster.id == instance.cluster_id, Cluster.deleted_at.is_(None))
         )

--- a/nodeskclaw-backend/app/services/instance_service.py
+++ b/nodeskclaw-backend/app/services/instance_service.py
@@ -1,5 +1,7 @@
 """Instance service: list, detail, delete, scale, restart, config save/apply."""
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
@@ -18,6 +20,7 @@ from app.models.deploy_record import DeployAction, DeployRecord, DeployStatus
 from app.models.instance import Instance, InstanceStatus
 from app.schemas.deploy import DeployRecordInfo
 from app.schemas.instance import InstanceDetail, InstanceInfo, UpdateConfigRequest, WorkspaceBrief
+from app.services.runtime.compute.base import ComputeHandle
 from app.utils.display_status import compute_display_status
 from app.services.k8s.client_manager import k8s_manager
 from app.services.k8s.k8s_client import K8sClient
@@ -77,8 +80,7 @@ def _k8s_name(instance: Instance) -> str:
     return instance.slug or instance.name
 
 
-def _build_docker_handle(instance: Instance) -> "ComputeHandle":
-    from app.services.runtime.compute.base import ComputeHandle
+def _build_docker_handle(instance: Instance) -> ComputeHandle:
     advanced = json.loads(instance.advanced_config) if instance.advanced_config else {}
     return ComputeHandle(
         provider="docker", instance_id=instance.id,
@@ -207,19 +209,20 @@ async def list_instances(
     return items
 
 
-async def get_instance(instance_id: str, db: AsyncSession) -> Instance:
-    result = await db.execute(
-        select(Instance).where(Instance.id == instance_id, Instance.deleted_at.is_(None))
-    )
+async def get_instance(instance_id: str, db: AsyncSession, org_id: str | None = None) -> Instance:
+    query = select(Instance).where(Instance.id == instance_id, Instance.deleted_at.is_(None))
+    if org_id is not None:
+        query = query.where(Instance.org_id == org_id)
+    result = await db.execute(query)
     instance = result.scalar_one_or_none()
     if not instance:
         raise NotFoundError("实例不存在")
     return instance
 
 
-async def get_instance_detail(instance_id: str, db: AsyncSession) -> InstanceDetail:
+async def get_instance_detail(instance_id: str, db: AsyncSession, org_id: str | None = None) -> InstanceDetail:
     """Get instance info enriched with live K8s pod data."""
-    instance = await get_instance(instance_id, db)
+    instance = await get_instance(instance_id, db, org_id)
 
     wa_result = await db.execute(
         select(WorkspaceAgent, Workspace).join(
@@ -370,9 +373,9 @@ async def get_instance_detail(instance_id: str, db: AsyncSession) -> InstanceDet
     return detail
 
 
-async def delete_instance(instance_id: str, db: AsyncSession, delete_k8s: bool = True):
+async def delete_instance(instance_id: str, db: AsyncSession, delete_k8s: bool = True, org_id: str | None = None):
     """逻辑删除实例：标记 deleted_at，从 K8s 删除整个命名空间（级联删除所有资源）。"""
-    instance = await get_instance(instance_id, db)
+    instance = await get_instance(instance_id, db, org_id)
 
     wa_count_result = await db.execute(
         select(func.count()).select_from(WorkspaceAgent).where(
@@ -438,8 +441,8 @@ async def delete_instance(instance_id: str, db: AsyncSession, delete_k8s: bool =
     await db.commit()
 
 
-async def scale_instance(instance_id: str, replicas: int, db: AsyncSession):
-    instance = await get_instance(instance_id, db)
+async def scale_instance(instance_id: str, replicas: int, db: AsyncSession, org_id: str | None = None):
+    instance = await get_instance(instance_id, db, org_id)
 
     if instance.compute_provider == "docker":
         provider = _get_docker_provider()
@@ -464,8 +467,8 @@ async def scale_instance(instance_id: str, replicas: int, db: AsyncSession):
     await db.commit()
 
 
-async def restart_instance(instance_id: str, db: AsyncSession):
-    instance = await get_instance(instance_id, db)
+async def restart_instance(instance_id: str, db: AsyncSession, org_id: str | None = None):
+    instance = await get_instance(instance_id, db, org_id)
 
     if instance.compute_provider == "docker":
         provider = _get_docker_provider()
@@ -589,7 +592,8 @@ async def _monitor_restart(
         logger.exception("重启超时后恢复状态失败: instance=%s", instance_id)
 
 
-async def get_deploy_history(instance_id: str, db: AsyncSession) -> list[DeployRecordInfo]:
+async def get_deploy_history(instance_id: str, db: AsyncSession, org_id: str | None = None) -> list[DeployRecordInfo]:
+    await get_instance(instance_id, db, org_id)
     result = await db.execute(
         select(DeployRecord)
         .where(DeployRecord.instance_id == instance_id, DeployRecord.deleted_at.is_(None))
@@ -599,9 +603,14 @@ async def get_deploy_history(instance_id: str, db: AsyncSession) -> list[DeployR
 
 
 async def get_pod_logs(
-    instance_id: str, pod_name: str, db: AsyncSession, container: str | None = None, tail_lines: int = 200
+    instance_id: str,
+    pod_name: str,
+    db: AsyncSession,
+    container: str | None = None,
+    tail_lines: int = 200,
+    org_id: str | None = None,
 ) -> str:
-    instance = await get_instance(instance_id, db)
+    instance = await get_instance(instance_id, db, org_id)
 
     if instance.compute_provider == "docker":
         provider = _get_docker_provider()
@@ -625,12 +634,12 @@ async def get_pod_logs(
 # ────────────────────────────────────────────────────────────
 
 async def save_config(
-    instance_id: str, req: UpdateConfigRequest, db: AsyncSession
+    instance_id: str, req: UpdateConfigRequest, db: AsyncSession, org_id: str | None = None
 ) -> InstanceInfo:
     """
     Step 1: 仅保存配置变更到 pending_config，不执行 K8s 操作。
     """
-    instance = await get_instance(instance_id, db)
+    instance = await get_instance(instance_id, db, org_id)
 
     pending = {
         "image_version": req.image_version,
@@ -655,12 +664,12 @@ async def save_config(
 
 
 async def apply_config(
-    instance_id: str, user_id: str, db: AsyncSession
+    instance_id: str, user_id: str, db: AsyncSession, org_id: str | None = None
 ) -> InstanceInfo:
     """
     Step 2: 读取 pending_config，执行 K8s 滚动更新，成功后清空 pending_config。
     """
-    instance = await get_instance(instance_id, db)
+    instance = await get_instance(instance_id, db, org_id)
 
     if not instance.pending_config:
         raise NotFoundError("没有待应用的配置变更")
@@ -678,10 +687,10 @@ async def apply_config(
 
 
 async def update_config(
-    instance_id: str, req: UpdateConfigRequest, user_id: str, db: AsyncSession
+    instance_id: str, req: UpdateConfigRequest, user_id: str, db: AsyncSession, org_id: str | None = None
 ) -> InstanceInfo:
     """兼容旧接口: 直接保存 + 应用（供回滚等场景使用）。"""
-    instance = await get_instance(instance_id, db)
+    instance = await get_instance(instance_id, db, org_id)
     return await _execute_config_update(instance, req, user_id, db)
 
 
@@ -855,9 +864,9 @@ async def _execute_config_update(
     return InstanceInfo.model_validate(instance)
 
 
-async def sync_gateway_token(instance_id: str, db: AsyncSession) -> str:
+async def sync_gateway_token(instance_id: str, db: AsyncSession, org_id: str | None = None) -> str:
     """从运行中的 Pod 读取 GATEWAY_TOKEN 并回填到 DB 和 ConfigMap。"""
-    instance = await get_instance(instance_id, db)
+    instance = await get_instance(instance_id, db, org_id)
 
     env_vars = json.loads(instance.env_vars) if instance.env_vars else {}
     existing_token = env_vars.get("GATEWAY_TOKEN")
@@ -928,9 +937,9 @@ async def sync_gateway_token(instance_id: str, db: AsyncSession) -> str:
     return token
 
 
-async def regenerate_gateway_token(instance_id: str, db: AsyncSession) -> str:
+async def regenerate_gateway_token(instance_id: str, db: AsyncSession, org_id: str | None = None) -> str:
     """生成新的访问令牌，更新配置并触发实例重启。"""
-    instance = await get_instance(instance_id, db)
+    instance = await get_instance(instance_id, db, org_id)
     old_env_vars_json = instance.env_vars
     old_env_vars = json.loads(instance.env_vars) if instance.env_vars else {}
     old_proxy_token = instance.proxy_token
@@ -961,18 +970,18 @@ async def regenerate_gateway_token(instance_id: str, db: AsyncSession) -> str:
         logger.exception("更新实例访问令牌失败: instance=%s", instance_id)
         await db.rollback()
         try:
-            fresh_instance = await get_instance(instance_id, db)
+            fresh_instance = await get_instance(instance_id, db, org_id)
             await _replace_instance_configmap(fresh_instance, old_env_vars, k8s)
         except Exception:
             logger.exception("恢复旧访问令牌 ConfigMap 失败: instance=%s", instance_id)
         raise ConflictError("重设访问令牌失败，请稍后重试") from exc
 
     try:
-        await restart_instance(instance_id, db)
+        await restart_instance(instance_id, db, org_id)
     except Exception as exc:
         logger.exception("访问令牌更新后触发重启失败: instance=%s", instance_id)
         try:
-            rollback_instance = await get_instance(instance_id, db)
+            rollback_instance = await get_instance(instance_id, db, org_id)
             rollback_instance.env_vars = old_env_vars_json
             rollback_instance.proxy_token = old_proxy_token
             await _replace_instance_configmap(rollback_instance, old_env_vars, k8s)
@@ -986,10 +995,10 @@ async def regenerate_gateway_token(instance_id: str, db: AsyncSession) -> str:
 
 
 async def rollback_instance(
-    instance_id: str, target_revision: int, user_id: str, db: AsyncSession
+    instance_id: str, target_revision: int, user_id: str, db: AsyncSession, org_id: str | None = None
 ) -> InstanceInfo:
     """回滚实例到指定版本。"""
-    await get_instance(instance_id, db)
+    await get_instance(instance_id, db, org_id)
 
     # 查找目标版本记录
     result = await db.execute(
@@ -1020,4 +1029,4 @@ async def rollback_instance(
         env_vars=env_vars,
     )
 
-    return await update_config(instance_id, req, user_id, db)
+    return await update_config(instance_id, req, user_id, db, org_id)


### PR DESCRIPTION
## Summary

- 为管理端实例详情、删除、扩缩容、重启、历史、配置、日志、token 管理补当前组织约束
- 为 `instance_service` 增加可选 `org_id` 受限读取入口，并在管理端链路透传
- 保持 Portal 现有实例成员权限模型不变

## Root Cause

- 管理端实例接口原本只要求登录，不校验目标实例是否属于当前组织
- `instance_service.get_instance()` 只按 `instance_id` 查实例，导致上层很容易绕过组织边界

## Impact

- 当前组织之外的实例不能再通过管理端实例接口读取或操作
- 实例详情、部署历史、Pod 日志、配置变更、重启、回滚、token 同步这几条链统一收口

## Validation

- `cd nodeskclaw-backend && uv run ruff check app/api/instances.py app/services/instance_service.py`

Closes #143
