### PR TITLE
fix(genes): 收紧实例级基因访问边界

### DIFF
--- a/nodeskclaw-backend/app/api/genes.py
+++ b/nodeskclaw-backend/app/api/genes.py
@@ -3,7 +3,7 @@
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.deps import get_db
+from app.core.deps import get_current_org, get_db
 from app.core.exceptions import BadRequestError
 from app.core.security import get_current_user
 from app.models.user import User
@@ -198,9 +198,10 @@ async def rate_genome(
 async def instance_genes(
     instance_id: str,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
-    genes = await gene_service.get_instance_genes(db, instance_id)
+    _current_user, org = org_ctx
+    genes = await gene_service.get_instance_genes(db, instance_id, org.id)
     return ApiResponse(data=genes)
 
 
@@ -208,9 +209,10 @@ async def instance_genes(
 async def instance_skills(
     instance_id: str,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
-    skills = await gene_service.get_instance_skills(db, instance_id)
+    _current_user, org = org_ctx
+    skills = await gene_service.get_instance_skills(db, instance_id, org.id)
     return ApiResponse(data=skills)
 
 
@@ -219,9 +221,10 @@ async def install_gene(
     instance_id: str,
     req: InstallGeneRequest,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
-    result = await gene_service.install_gene(db, instance_id, req.gene_slug)
+    _current_user, org = org_ctx
+    result = await gene_service.install_gene(db, instance_id, req.gene_slug, org_id=org.id)
     return ApiResponse(data=result)
 
 
@@ -230,9 +233,10 @@ async def uninstall_gene(
     instance_id: str,
     req: UninstallGeneRequest,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
-    result = await gene_service.uninstall_gene(db, instance_id, req.gene_id)
+    _current_user, org = org_ctx
+    result = await gene_service.uninstall_gene(db, instance_id, req.gene_id, org_id=org.id)
     return ApiResponse(data=result)
 
 
@@ -241,9 +245,10 @@ async def apply_genome(
     instance_id: str,
     req: ApplyGenomeRequest,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
-    result = await gene_service.apply_genome(db, instance_id, req.genome_id)
+    _current_user, org = org_ctx
+    result = await gene_service.apply_genome(db, instance_id, req.genome_id, org.id)
     return ApiResponse(data=result)
 
 
@@ -258,8 +263,10 @@ async def publish_variant(
     gene_id: str,
     req: PublishVariantRequest,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
+    _current_user, org = org_ctx
+    await gene_service.get_instance_genes(db, instance_id, org.id)
     result = await gene_service.publish_variant(
         db, instance_id, gene_id, req.variant_name, req.variant_slug
     )
@@ -272,8 +279,10 @@ async def log_effectiveness(
     gene_id: str,
     req: EffectivenessRequest,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
+    _current_user, org = org_ctx
+    await gene_service.get_instance_genes(db, instance_id, org.id)
     result = await gene_service.log_effectiveness(
         db, instance_id, gene_id, req.metric_type, req.value, req.context
     )
@@ -285,9 +294,10 @@ async def create_gene_from_agent(
     instance_id: str,
     req: CreateGeneRequest,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
-    result = await gene_service.trigger_gene_creation(db, instance_id, req.creation_prompt)
+    _current_user, org = org_ctx
+    result = await gene_service.trigger_gene_creation(db, instance_id, req.creation_prompt, org.id)
     return ApiResponse(data=result)
 
 
@@ -352,9 +362,10 @@ async def get_evolution_log(
     page: int = 1,
     page_size: int = 20,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
-    events = await gene_service.get_evolution_log(db, instance_id, page, page_size)
+    _current_user, org = org_ctx
+    events = await gene_service.get_evolution_log(db, instance_id, page, page_size, org.id)
     return ApiResponse(data=events)
 
 

--- a/nodeskclaw-backend/app/services/gene_service.py
+++ b/nodeskclaw-backend/app/services/gene_service.py
@@ -745,7 +745,10 @@ async def get_featured_genomes(db: AsyncSession, limit: int = 10) -> list[dict]:
 # ═══════════════════════════════════════════════════
 
 
-async def get_instance_genes(db: AsyncSession, instance_id: str) -> list[dict]:
+async def get_instance_genes(db: AsyncSession, instance_id: str, org_id: str | None = None) -> list[dict]:
+    from app.services.instance_service import get_instance
+
+    await get_instance(instance_id, db, org_id)
     q = (
         select(InstanceGene, Gene)
         .join(Gene, InstanceGene.gene_id == Gene.id)
@@ -834,7 +837,7 @@ def _build_db_only_items(ig_rows: list) -> list[dict]:
     return items
 
 
-async def get_instance_skills(db: AsyncSession, instance_id: str) -> list[dict]:
+async def get_instance_skills(db: AsyncSession, instance_id: str, org_id: str | None = None) -> list[dict]:
     """Return the merged skill list driven by Pod filesystem + DB enrichment.
 
     Each item is typed ``hub`` (matched Gene Hub entry) or ``emerged``
@@ -845,7 +848,7 @@ async def get_instance_skills(db: AsyncSession, instance_id: str) -> list[dict]:
     """
     from app.services.instance_service import get_instance
 
-    instance = await get_instance(instance_id, db)
+    instance = await get_instance(instance_id, db, org_id)
 
     ig_result = await db.execute(
         select(InstanceGene, Gene)
@@ -1047,11 +1050,12 @@ async def install_gene(
     instance_id: str,
     gene_slug: str,
     genome_id: str | None = None,
+    org_id: str | None = None,
 ) -> dict:
     from app.api.workspaces import broadcast_event
     from app.services.instance_service import get_instance
 
-    instance = await get_instance(instance_id, db)
+    instance = await get_instance(instance_id, db, org_id)
 
     gene = await get_gene_by_slug(db, gene_slug)
 
@@ -1590,7 +1594,15 @@ async def handle_learning_callback(
 # ── Apply Genome ─────────────────────────────────
 
 
-async def apply_genome(db: AsyncSession, instance_id: str, genome_id: str) -> dict:
+async def apply_genome(
+    db: AsyncSession,
+    instance_id: str,
+    genome_id: str,
+    org_id: str | None = None,
+) -> dict:
+    from app.services.instance_service import get_instance
+
+    await get_instance(instance_id, db, org_id)
     genome_result = await db.execute(
         select(Genome).where(Genome.id == genome_id, not_deleted(Genome))
     )
@@ -1619,7 +1631,7 @@ async def apply_genome(db: AsyncSession, instance_id: str, genome_id: str) -> di
             results["skipped"].append(slug)
             continue
         try:
-            await install_gene(db, instance_id, slug, genome_id=genome.id)
+            await install_gene(db, instance_id, slug, genome_id=genome.id, org_id=org_id)
             results["installed"].append(slug)
         except AppException:
             results["skipped"].append(slug)
@@ -1965,10 +1977,11 @@ async def trigger_gene_creation(
     db: AsyncSession,
     instance_id: str,
     creation_prompt: str | None = None,
+    org_id: str | None = None,
 ) -> dict:
     from app.services.instance_service import get_instance
 
-    instance = await get_instance(instance_id, db)
+    instance = await get_instance(instance_id, db, org_id)
     import uuid
 
     task_id = str(uuid.uuid4())
@@ -2223,10 +2236,15 @@ async def refresh_gene_skills(db: AsyncSession, gene_slugs: list[str]) -> dict:
     return {"refreshed": refreshed, "failed": failed}
 
 
-async def uninstall_gene(db: AsyncSession, instance_id: str, gene_id: str) -> dict:
+async def uninstall_gene(
+    db: AsyncSession,
+    instance_id: str,
+    gene_id: str,
+    org_id: str | None = None,
+) -> dict:
     from app.services.instance_service import get_instance
 
-    await get_instance(instance_id, db)
+    await get_instance(instance_id, db, org_id)
 
     ig_result = await db.execute(
         select(InstanceGene).where(
@@ -2478,7 +2496,11 @@ async def get_evolution_log(
     instance_id: str,
     page: int = 1,
     page_size: int = 20,
+    org_id: str | None = None,
 ) -> list[dict]:
+    from app.services.instance_service import get_instance
+
+    await get_instance(instance_id, db, org_id)
     offset = (page - 1) * page_size
     result = await db.execute(
         select(EvolutionEvent)


### PR DESCRIPTION
## 背景
管理端 `genes` 的实例级接口此前只依赖 `instance_id`，没有校验实例是否属于当前组织，存在跨组织读取和操作实例基因的风险。

## 变更
- 为管理端实例级基因接口统一接入当前组织上下文
- 在 `gene_service` 的实例级查询、安装、卸载、应用 genome、触发创造、查看进化日志等链路补上组织范围校验
- 为暂未改造签名的发布变体/记录效果接口增加实例归属预校验

## 验证
- `cd nodeskclaw-backend && uv run ruff check app/api/genes.py app/services/gene_service.py`

Closes #145