### PR TITLE
fix(clusters): 收紧集群组织访问边界

### DIFF
--- a/nodeskclaw-backend/app/api/clusters.py
+++ b/nodeskclaw-backend/app/api/clusters.py
@@ -3,33 +3,28 @@
 import logging
 
 from fastapi import APIRouter, Depends
-
-logger = logging.getLogger(__name__)
 from pydantic import BaseModel
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core import hooks
 from app.core.deps import get_current_org, get_db
-from app.core.exceptions import NotFoundError
-from app.core.security import get_current_user
-from app.models.cluster import Cluster
-from app.models.user import User
 from app.schemas.cluster import ClusterCreate, ClusterInfo, ClusterUpdate, ConnectionTestResult
 from app.schemas.common import ApiResponse
 from app.services import cluster_service
 from app.services.runtime.registries.compute_registry import require_k8s_client
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
 @router.get("", response_model=ApiResponse[list[ClusterInfo]])
 async def list_clusters(
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """集群列表。"""
-    data = await cluster_service.list_clusters(db)
+    _current_user, org = org_ctx
+    data = await cluster_service.list_clusters(db, org.id)
     return ApiResponse(data=data)
 
 
@@ -50,10 +45,11 @@ async def create_cluster(
 async def get_cluster(
     cluster_id: str,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """集群详情。"""
-    cluster = await cluster_service.get_cluster(cluster_id, db)
+    _current_user, org = org_ctx
+    cluster = await cluster_service.get_cluster(cluster_id, db, org.id)
     return ApiResponse(data=ClusterInfo.model_validate(cluster))
 
 
@@ -62,11 +58,12 @@ async def update_cluster(
     cluster_id: str,
     body: ClusterUpdate,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """更新集群配置。"""
-    data = await cluster_service.update_cluster(cluster_id, body, db)
-    await hooks.emit("operation_audit", action="cluster.updated", target_type="cluster", target_id=cluster_id, actor_id=_current_user.id, org_id=_current_user.current_org_id)
+    current_user, org = org_ctx
+    data = await cluster_service.update_cluster(cluster_id, body, db, org.id)
+    await hooks.emit("operation_audit", action="cluster.updated", target_type="cluster", target_id=cluster_id, actor_id=current_user.id, org_id=org.id)
     return ApiResponse(data=data)
 
 
@@ -74,11 +71,12 @@ async def update_cluster(
 async def delete_cluster(
     cluster_id: str,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """删除集群。"""
-    await cluster_service.delete_cluster(cluster_id, db)
-    await hooks.emit("operation_audit", action="cluster.deleted", target_type="cluster", target_id=cluster_id, actor_id=_current_user.id, org_id=_current_user.current_org_id)
+    current_user, org = org_ctx
+    await cluster_service.delete_cluster(cluster_id, db, org.id)
+    await hooks.emit("operation_audit", action="cluster.deleted", target_type="cluster", target_id=cluster_id, actor_id=current_user.id, org_id=org.id)
     return ApiResponse(message="集群已删除")
 
 
@@ -86,12 +84,13 @@ async def delete_cluster(
 async def cluster_health(
     cluster_id: str,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """集群健康详情 + Token 过期检测。"""
     from app.services.health_checker import get_cluster_health
 
-    data = await get_cluster_health(cluster_id, db)
+    _current_user, org = org_ctx
+    data = await get_cluster_health(cluster_id, db, org.id)
     return ApiResponse(data=data)
 
 
@@ -99,15 +98,11 @@ async def cluster_health(
 async def cluster_overview(
     cluster_id: str,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """集群概览: 资源汇总 + 节点列表。"""
-    result = await db.execute(
-        select(Cluster).where(Cluster.id == cluster_id, Cluster.deleted_at.is_(None))
-    )
-    cluster = result.scalar_one_or_none()
-    if not cluster:
-        raise NotFoundError("集群不存在")
+    _current_user, org = org_ctx
+    cluster = await cluster_service.get_cluster(cluster_id, db, org.id)
 
     k8s = await require_k8s_client(cluster)
 
@@ -172,10 +167,11 @@ async def cluster_overview(
 async def test_connection(
     cluster_id: str,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """测试集群连接。"""
-    data = await cluster_service.test_connection(cluster_id, db)
+    _current_user, org = org_ctx
+    data = await cluster_service.test_connection(cluster_id, db, org.id)
     return ApiResponse(data=data)
 
 
@@ -188,9 +184,10 @@ async def update_kubeconfig(
     cluster_id: str,
     body: KubeconfigBody,
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """更新 KubeConfig（重建连接）。"""
-    data = await cluster_service.update_kubeconfig(cluster_id, body.kubeconfig, db)
-    await hooks.emit("operation_audit", action="cluster.kubeconfig_updated", target_type="cluster", target_id=cluster_id, actor_id=_current_user.id, org_id=_current_user.current_org_id)
+    current_user, org = org_ctx
+    data = await cluster_service.update_kubeconfig(cluster_id, body.kubeconfig, db, org.id)
+    await hooks.emit("operation_audit", action="cluster.kubeconfig_updated", target_type="cluster", target_id=cluster_id, actor_id=current_user.id, org_id=org.id)
     return ApiResponse(data=data)

--- a/nodeskclaw-backend/app/api/events.py
+++ b/nodeskclaw-backend/app/api/events.py
@@ -8,14 +8,11 @@ import logging
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse, StreamingResponse
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.deps import get_db
-from app.core.exceptions import NotFoundError
-from app.core.security import get_current_user
-from app.models.cluster import Cluster
-from app.models.user import User
+from app.core.deps import get_current_org, get_db
+from app.services import cluster_service
+from app.services.k8s.k8s_client import K8sClient
 from app.services.runtime.registries.compute_registry import require_k8s_client
 
 logger = logging.getLogger(__name__)
@@ -46,26 +43,17 @@ def _map_k8s_event(obj, event_type: str = "OBJECT") -> dict:
     }
 
 
-async def _get_cluster(cluster_id: str, db: AsyncSession) -> Cluster:
-    result = await db.execute(
-        select(Cluster).where(Cluster.id == cluster_id, Cluster.deleted_at.is_(None))
-    )
-    cluster = result.scalar_one_or_none()
-    if not cluster:
-        raise NotFoundError("集群不存在")
-    return cluster
-
-
 @router.get("/recent")
 async def events_recent(
     cluster_id: str = Query(..., description="集群 ID"),
     namespace: str = Query("", description="命名空间，留空则查询所有"),
     limit: int = Query(100, ge=1, le=500, description="返回条数上限"),
     db: AsyncSession = Depends(get_db),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """REST: 返回 K8s 最近事件列表。非 K8s 集群返回空列表。"""
-    cluster = await _get_cluster(cluster_id, db)
+    _current_user, org = org_ctx
+    cluster = await cluster_service.get_cluster(cluster_id, db, org.id)
 
     if not cluster.is_k8s:
         return JSONResponse({"data": []})
@@ -87,13 +75,14 @@ async def events_recent(
 async def events_stream(
     cluster_id: str = Query(..., description="集群 ID"),
     namespace: str = Query("", description="命名空间，留空则监听所有"),
-    _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """SSE 流: 实时推送 K8s 事件（deprecated，保留兼容）。"""
     from app.core.deps import async_session_factory
 
+    _current_user, org = org_ctx
     async with async_session_factory() as db:
-        cluster = await _get_cluster(cluster_id, db)
+        cluster = await cluster_service.get_cluster(cluster_id, db, org.id)
     k8s = await require_k8s_client(cluster)
 
     async def generate():

--- a/nodeskclaw-backend/app/services/cluster_service.py
+++ b/nodeskclaw-backend/app/services/cluster_service.py
@@ -23,10 +23,11 @@ from app.schemas.cluster import ClusterCreate, ClusterInfo, ClusterUpdate, Conne
 logger = logging.getLogger(__name__)
 
 
-async def list_clusters(db: AsyncSession) -> list[ClusterInfo]:
-    result = await db.execute(
-        select(Cluster).where(Cluster.deleted_at.is_(None)).order_by(Cluster.created_at.desc())
-    )
+async def list_clusters(db: AsyncSession, org_id: str | None = None) -> list[ClusterInfo]:
+    query = select(Cluster).where(Cluster.deleted_at.is_(None))
+    if org_id:
+        query = query.where(Cluster.org_id == org_id)
+    result = await db.execute(query.order_by(Cluster.created_at.desc()))
     clusters = result.scalars().all()
     return [ClusterInfo.model_validate(c) for c in clusters]
 
@@ -92,18 +93,21 @@ async def create_cluster(
     return ClusterInfo.model_validate(cluster)
 
 
-async def get_cluster(cluster_id: str, db: AsyncSession) -> Cluster:
-    result = await db.execute(
-        select(Cluster).where(Cluster.id == cluster_id, Cluster.deleted_at.is_(None))
-    )
+async def get_cluster(cluster_id: str, db: AsyncSession, org_id: str | None = None) -> Cluster:
+    query = select(Cluster).where(Cluster.id == cluster_id, Cluster.deleted_at.is_(None))
+    if org_id:
+        query = query.where(Cluster.org_id == org_id)
+    result = await db.execute(query)
     cluster = result.scalar_one_or_none()
     if not cluster:
         raise NotFoundError("集群不存在")
     return cluster
 
 
-async def update_cluster(cluster_id: str, data: ClusterUpdate, db: AsyncSession) -> ClusterInfo:
-    cluster = await get_cluster(cluster_id, db)
+async def update_cluster(
+    cluster_id: str, data: ClusterUpdate, db: AsyncSession, org_id: str | None = None,
+) -> ClusterInfo:
+    cluster = await get_cluster(cluster_id, db, org_id)
     if data.name is not None:
         cluster.name = data.name
     if data.provider is not None:
@@ -121,9 +125,9 @@ async def update_cluster(cluster_id: str, data: ClusterUpdate, db: AsyncSession)
     return ClusterInfo.model_validate(cluster)
 
 
-async def delete_cluster(cluster_id: str, db: AsyncSession) -> None:
+async def delete_cluster(cluster_id: str, db: AsyncSession, org_id: str | None = None) -> None:
     """逻辑删除集群，级联逻辑删除其下所有实例和部署记录。"""
-    cluster = await get_cluster(cluster_id, db)
+    cluster = await get_cluster(cluster_id, db, org_id)
 
     # 查询该集群下所有未删除的实例
     inst_result = await db.execute(
@@ -190,8 +194,10 @@ async def delete_cluster(cluster_id: str, db: AsyncSession) -> None:
     await db.commit()
 
 
-async def update_kubeconfig(cluster_id: str, kubeconfig: str, db: AsyncSession) -> ClusterInfo:
-    cluster = await get_cluster(cluster_id, db)
+async def update_kubeconfig(
+    cluster_id: str, kubeconfig: str, db: AsyncSession, org_id: str | None = None,
+) -> ClusterInfo:
+    cluster = await get_cluster(cluster_id, db, org_id)
     api_server_url, auth_type = _parse_kubeconfig_meta(kubeconfig)
     cluster.credentials_encrypted = encrypt_kubeconfig(kubeconfig)
     cluster.set_provider_value("auth_type", auth_type)
@@ -298,9 +304,11 @@ async def _create_docker_cluster(
     return ClusterInfo.model_validate(cluster)
 
 
-async def test_connection(cluster_id: str, db: AsyncSession) -> ConnectionTestResult:
+async def test_connection(
+    cluster_id: str, db: AsyncSession, org_id: str | None = None,
+) -> ConnectionTestResult:
     """Test cluster connectivity."""
-    cluster = await get_cluster(cluster_id, db)
+    cluster = await get_cluster(cluster_id, db, org_id)
 
     if cluster.compute_provider == "docker":
         return await _test_docker_connection(cluster, db)

--- a/nodeskclaw-backend/app/services/health_checker.py
+++ b/nodeskclaw-backend/app/services/health_checker.py
@@ -100,11 +100,12 @@ class HealthChecker:
             )
 
 
-async def get_cluster_health(cluster_id: str, db) -> dict:
+async def get_cluster_health(cluster_id: str, db, org_id: str | None = None) -> dict:
     """Return health details for a single cluster."""
-    result = await db.execute(
-        select(Cluster).where(Cluster.id == cluster_id, Cluster.deleted_at.is_(None))
-    )
+    query = select(Cluster).where(Cluster.id == cluster_id, Cluster.deleted_at.is_(None))
+    if org_id:
+        query = query.where(Cluster.org_id == org_id)
+    result = await db.execute(query)
     cluster = result.scalar_one_or_none()
     if not cluster:
         from app.core.exceptions import NotFoundError


### PR DESCRIPTION
## 背景
管理端 `clusters` 相关接口此前对集群资源按 `cluster_id` 全局查询，没有按当前组织约束，存在跨组织查看和操作集群的风险。

## 变更
- 为 `cluster_service` 的列表、详情、更新、删除、连接测试、KubeConfig 更新统一补上 `org_id` 过滤
- 为集群健康和概览接口接入当前组织校验
- 同步收紧依赖 `cluster_id` 的事件查询和事件流接口，避免同源逻辑漏口

## 验证
- `cd nodeskclaw-backend && uv run ruff check app/api/clusters.py app/api/events.py app/services/cluster_service.py app/services/health_checker.py`

Closes #146