### PR TITLE
fix(channel): 聚合飞书连续入站消息

### DIFF
--- a/nodeskclaw-backend/app/services/channel_adapters/feishu_ws_client.py
+++ b/nodeskclaw-backend/app/services/channel_adapters/feishu_ws_client.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import json
 import logging
 import threading
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable
 
 import lark_oapi as lark
 from lark_oapi.api.im.v1.model.p2_im_message_receive_v1 import P2ImMessageReceiveV1
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+FEISHU_MESSAGE_BUFFER_WINDOW_SECONDS = 1.5
 
 
 async def _handle_message_event(
@@ -128,6 +130,85 @@ def _extract_text_content(message: dict) -> str:
     return f"[{msg_type} message]"
 
 
+@dataclass
+class _BufferedMessageBatch:
+    messages: list[str] = field(default_factory=list)
+    generation: int = 0
+    timer: threading.Timer | None = None
+
+
+class _FeishuMessageBatcher:
+    def __init__(
+        self,
+        handler: Callable[[str, str, str], None],
+        window_seconds: float = FEISHU_MESSAGE_BUFFER_WINDOW_SECONDS,
+        timer_factory: Callable[..., threading.Timer] = threading.Timer,
+    ):
+        self._handler = handler
+        self._window_seconds = window_seconds
+        self._timer_factory = timer_factory
+        self._lock = threading.Lock()
+        self._batches: dict[tuple[str, str], _BufferedMessageBatch] = {}
+
+    def add(self, chat_id: str, sender_open_id: str, message: dict) -> None:
+        fragment = _extract_text_content(message).strip()
+        if not fragment:
+            return
+
+        key = (chat_id, sender_open_id)
+        with self._lock:
+            batch = self._batches.get(key)
+            if batch is None:
+                batch = _BufferedMessageBatch()
+                self._batches[key] = batch
+
+            batch.messages.append(fragment)
+            batch.generation += 1
+
+            if batch.timer is not None:
+                batch.timer.cancel()
+
+            timer = self._timer_factory(
+                self._window_seconds,
+                self._flush_if_current,
+                args=(key, batch.generation),
+            )
+            timer.daemon = True
+            batch.timer = timer
+            timer.start()
+
+    def flush_all(self) -> None:
+        with self._lock:
+            pending = list(self._batches.items())
+            self._batches = {}
+
+        for key, batch in pending:
+            if batch.timer is not None:
+                batch.timer.cancel()
+            self._emit(batch.messages, chat_id=key[0], sender_open_id=key[1])
+
+    def _flush_if_current(self, key: tuple[str, str], generation: int) -> None:
+        with self._lock:
+            batch = self._batches.get(key)
+            if batch is None or batch.generation != generation:
+                return
+            self._batches.pop(key, None)
+            messages = list(batch.messages)
+
+        self._emit(messages, chat_id=key[0], sender_open_id=key[1])
+
+    def _emit(
+        self,
+        messages: list[str],
+        *,
+        chat_id: str = "",
+        sender_open_id: str = "",
+    ) -> None:
+        content = "\n".join(part for part in messages if part).strip()
+        if content:
+            self._handler(chat_id, sender_open_id, content)
+
+
 class FeishuWSClient:
     """Manages a single Feishu WebSocket long-connection for one app."""
 
@@ -136,6 +217,7 @@ class FeishuWSClient:
         self._app_secret = app_secret
         self._thread: threading.Thread | None = None
         self._client: LarkWSClient | None = None
+        self._batcher = _FeishuMessageBatcher(self._dispatch_message_batch)
 
         handler = (
             EventDispatcherHandler.builder(encrypt_key, verification_token)
@@ -150,10 +232,21 @@ class FeishuWSClient:
             log_level=lark.LogLevel.WARNING,
         )
 
-    def _on_message(self, event: P2ImMessageReceiveV1) -> None:
-        """Called by lark-oapi when im.message.receive_v1 arrives."""
+    @staticmethod
+    def _dispatch_message_batch(chat_id: str, sender_open_id: str, content: str) -> None:
         import asyncio
 
+        try:
+            loop = asyncio.new_event_loop()
+            loop.run_until_complete(
+                _handle_message_event(chat_id, sender_open_id, content)
+            )
+            loop.close()
+        except Exception as e:
+            logger.error("Feishu WS message handling error: %s", e)
+
+    def _on_message(self, event: P2ImMessageReceiveV1) -> None:
+        """Called by lark-oapi when im.message.receive_v1 arrives."""
         msg = event.event.message
         sender = event.event.sender
 
@@ -166,16 +259,7 @@ class FeishuWSClient:
                 "message_type": msg.message_type or "",
                 "content": msg.content or "",
             }
-        content = _extract_text_content(message_dict)
-
-        try:
-            loop = asyncio.new_event_loop()
-            loop.run_until_complete(
-                _handle_message_event(chat_id, sender_open_id, content)
-            )
-            loop.close()
-        except Exception as e:
-            logger.error("Feishu WS message handling error: %s", e)
+        self._batcher.add(chat_id, sender_open_id, message_dict)
 
     def start(self) -> None:
         """Start the WebSocket connection in a background daemon thread."""
@@ -195,4 +279,5 @@ class FeishuWSClient:
 
     def stop(self) -> None:
         """Best-effort shutdown. The daemon thread will terminate with the process."""
+        self._batcher.flush_all()
         logger.info("Stopping Feishu WS client: app_id=%s", self._app_id)

--- a/nodeskclaw-backend/tests/test_feishu_ws_client_buffer.py
+++ b/nodeskclaw-backend/tests/test_feishu_ws_client_buffer.py
@@ -1,0 +1,98 @@
+import json
+
+from app.services.channel_adapters.feishu_ws_client import _FeishuMessageBatcher
+
+
+class FakeTimer:
+    created: list["FakeTimer"] = []
+
+    def __init__(self, interval, callback, args=None, kwargs=None):
+        self.interval = interval
+        self.callback = callback
+        self.args = args or ()
+        self.kwargs = kwargs or {}
+        self.daemon = False
+        self.cancelled = False
+        FakeTimer.created.append(self)
+
+    def start(self):
+        return None
+
+    def cancel(self):
+        self.cancelled = True
+
+    def fire(self):
+        if not self.cancelled:
+            self.callback(*self.args, **self.kwargs)
+
+
+def test_message_batcher_merges_multiple_text_messages_within_window():
+    FakeTimer.created = []
+    handled: list[tuple[str, str, str]] = []
+    batcher = _FeishuMessageBatcher(
+        lambda chat_id, sender_open_id, content: handled.append((chat_id, sender_open_id, content)),
+        window_seconds=1.5,
+        timer_factory=FakeTimer,
+    )
+
+    batcher.add("chat-1", "user-1", {"message_type": "text", "content": json.dumps({"text": "第一条"})})
+    batcher.add("chat-1", "user-1", {"message_type": "text", "content": json.dumps({"text": "第二条"})})
+
+    assert len(FakeTimer.created) == 2
+    assert FakeTimer.created[0].cancelled is True
+
+    FakeTimer.created[1].fire()
+
+    assert handled == [("chat-1", "user-1", "第一条\n第二条")]
+
+
+def test_message_batcher_merges_mixed_message_types_in_order():
+    FakeTimer.created = []
+    handled: list[tuple[str, str, str]] = []
+    batcher = _FeishuMessageBatcher(
+        lambda chat_id, sender_open_id, content: handled.append((chat_id, sender_open_id, content)),
+        timer_factory=FakeTimer,
+    )
+
+    batcher.add("chat-2", "user-2", {"message_type": "image", "content": "{}"})
+    batcher.add("chat-2", "user-2", {"message_type": "text", "content": json.dumps({"text": "补一句"})})
+    batcher.add("chat-2", "user-2", {"message_type": "file", "content": "{}"})
+
+    FakeTimer.created[-1].fire()
+
+    assert handled == [("chat-2", "user-2", "[image message]\n补一句\n[file message]")]
+
+
+def test_message_batcher_separates_different_conversations():
+    FakeTimer.created = []
+    handled: list[tuple[str, str, str]] = []
+    batcher = _FeishuMessageBatcher(
+        lambda chat_id, sender_open_id, content: handled.append((chat_id, sender_open_id, content)),
+        timer_factory=FakeTimer,
+    )
+
+    batcher.add("chat-a", "user-1", {"message_type": "text", "content": json.dumps({"text": "A"})})
+    batcher.add("chat-b", "user-1", {"message_type": "text", "content": json.dumps({"text": "B"})})
+
+    FakeTimer.created[0].fire()
+    FakeTimer.created[1].fire()
+
+    assert handled == [
+        ("chat-a", "user-1", "A"),
+        ("chat-b", "user-1", "B"),
+    ]
+
+
+def test_message_batcher_flush_all_emits_pending_messages_once():
+    FakeTimer.created = []
+    handled: list[tuple[str, str, str]] = []
+    batcher = _FeishuMessageBatcher(
+        lambda chat_id, sender_open_id, content: handled.append((chat_id, sender_open_id, content)),
+        timer_factory=FakeTimer,
+    )
+
+    batcher.add("chat-3", "user-3", {"message_type": "text", "content": json.dumps({"text": "结束前消息"})})
+    batcher.flush_all()
+
+    assert handled == [("chat-3", "user-3", "结束前消息")]
+    assert FakeTimer.created[-1].cancelled is True


### PR DESCRIPTION
## 变更
- 为飞书 `im.message.receive_v1` 接收链路增加 1.5 秒聚合窗口
- 按 `chat_id + sender_open_id` 对连续消息做防抖聚合
- 对所有消息类型统一处理，按到达顺序合并后再触发一次 AI 处理
- 进程停止时主动 flush，避免缓存中的尾消息丢失

## 验证
- `uv run pytest tests/test_feishu_ws_client_buffer.py`

## 说明
- 文本消息保留原文
- 非文本消息保留类型占位，例如 `[image message]`
- 同一窗口内的混合消息会按顺序合并成一条内容后再进入现有处理链路