### PR TITLE
fix(runtime): 将队列清理改为软删除

### DIFF
--- a/nodeskclaw-backend/app/services/runtime/retention.py
+++ b/nodeskclaw-backend/app/services/runtime/retention.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import delete, update
+from sqlalchemy import func, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
@@ -40,8 +40,6 @@ async def compact_warm_event_logs(db: AsyncSession) -> int:
 
 async def cleanup_event_logs(db: AsyncSession, retention_days: int = WARM_RETENTION_DAYS) -> int:
     """Soft-delete event_logs older than warm tier."""
-    from sqlalchemy import func
-
     from app.models.event_log import EventLog
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
@@ -64,14 +62,17 @@ async def cleanup_consumed_queue_items(db: AsyncSession, retention_days: int = M
 
     cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
     result = await db.execute(
-        delete(MessageQueueItem).where(
+        update(MessageQueueItem)
+        .where(
             MessageQueueItem.status == "delivered",
             MessageQueueItem.created_at < cutoff,
+            MessageQueueItem.deleted_at.is_(None),
         )
+        .values(deleted_at=func.now())
     )
     count = result.rowcount or 0
     if count > 0:
-        logger.info("Retention: deleted %d consumed queue items older than %d days", count, retention_days)
+        logger.info("Retention: soft-deleted %d consumed queue items older than %d days", count, retention_days)
     return count
 
 

--- a/nodeskclaw-backend/tests/test_retention_queue_soft_delete.py
+++ b/nodeskclaw-backend/tests/test_retention_queue_soft_delete.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.message_queue import MessageQueueItem
+from app.services.runtime.retention import cleanup_consumed_queue_items
+
+TEST_DATABASE_URL = "postgresql+asyncpg://nodeskclaw:nodeskclaw@localhost:5432/nodeskclaw_test"
+engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+TestSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest.fixture
+async def require_test_db():
+    try:
+        async with engine.connect():
+            yield
+    except Exception:
+        pytest.skip("PostgreSQL test database is not available")
+
+
+@pytest.mark.asyncio
+async def test_cleanup_consumed_queue_items_uses_soft_delete(require_test_db):
+    async with TestSessionLocal() as db:
+        now = datetime.now(timezone.utc)
+        delivered_old = MessageQueueItem(
+            id="mq-delivered-old",
+            target_node_id="node-1",
+            workspace_id="ws-1",
+            status="delivered",
+            created_at=now - timedelta(days=10),
+            scheduled_at=now - timedelta(days=10),
+            envelope={"type": "test"},
+        )
+        delivered_recent = MessageQueueItem(
+            id="mq-delivered-recent",
+            target_node_id="node-1",
+            workspace_id="ws-1",
+            status="delivered",
+            created_at=now - timedelta(days=1),
+            scheduled_at=now - timedelta(days=1),
+            envelope={"type": "test"},
+        )
+        pending_old = MessageQueueItem(
+            id="mq-pending-old",
+            target_node_id="node-1",
+            workspace_id="ws-1",
+            status="pending",
+            created_at=now - timedelta(days=10),
+            scheduled_at=now - timedelta(days=10),
+            envelope={"type": "test"},
+        )
+        db.add_all([delivered_old, delivered_recent, pending_old])
+        await db.commit()
+
+        count = await cleanup_consumed_queue_items(db, retention_days=7)
+        await db.commit()
+
+        assert count == 1
+
+        rows = (
+            await db.execute(
+                select(MessageQueueItem).where(
+                    MessageQueueItem.id.in_([
+                        "mq-delivered-old",
+                        "mq-delivered-recent",
+                        "mq-pending-old",
+                    ])
+                )
+            )
+        ).scalars().all()
+        by_id = {row.id: row for row in rows}
+
+        assert len(by_id) == 3
+        assert by_id["mq-delivered-old"].deleted_at is not None
+        assert by_id["mq-delivered-recent"].deleted_at is None
+        assert by_id["mq-pending-old"].deleted_at is None


### PR DESCRIPTION
## 背景
retention 在清理已消费的 `message_queue` 记录时直接做了物理删除，这和仓库统一的软删除约定冲突，也会让历史队列数据不可恢复。

## 变更
- 将 `cleanup_consumed_queue_items()` 从 `delete()` 改为更新 `deleted_at`
- 为已软删除记录补上过滤，避免重复清理
- 补充队列清理软删除的回归测试

## 验证
- `cd nodeskclaw-backend && uv run ruff check app/services/runtime/retention.py tests/test_retention_queue_soft_delete.py`
- `cd nodeskclaw-backend && uv run pytest tests/test_retention_queue_soft_delete.py`
  - 当前环境缺少 `nodeskclaw_test` 数据库，测试被 skip

Closes #156