### PR TITLE
fix(storage): 收紧存储类查询边界

### DIFF
--- a/nodeskclaw-backend/app/api/storage.py
+++ b/nodeskclaw-backend/app/api/storage.py
@@ -8,7 +8,8 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.deps import get_db
+from app.core.deps import get_current_org, get_db
+from app.core.exceptions import BadRequestError, NotFoundError
 from app.core.security import get_current_user
 from app.models.cluster import Cluster
 from app.models.user import User
@@ -31,16 +32,37 @@ class StorageClassInfo(BaseModel):
     enabled: bool = False  # 是否被管理员启用（在 NoDeskClaw 允许列表中）
 
 
-async def _fetch_all_storage_classes(db: AsyncSession) -> list[StorageClassInfo]:
-    """从已连接集群获取全部 StorageClass。"""
+async def _resolve_storage_cluster(
+    db: AsyncSession, cluster_id: str | None, org_id: str,
+) -> Cluster | None:
+    """解析 StorageClass 查询目标集群。"""
+    filters = [
+        Cluster.org_id == org_id,
+        Cluster.status == "connected",
+        Cluster.compute_provider == "k8s",
+        Cluster.deleted_at.is_(None),
+    ]
+    if cluster_id:
+        result = await db.execute(select(Cluster).where(*filters, Cluster.id == cluster_id))
+        cluster = result.scalar_one_or_none()
+        if not cluster:
+            raise NotFoundError("集群不存在", "errors.cluster.not_found")
+        return cluster
+
     result = await db.execute(
-        select(Cluster).where(
-            Cluster.status == "connected",
-            Cluster.compute_provider == "k8s",
-            Cluster.deleted_at.is_(None),
-        )
+        select(Cluster).where(*filters).order_by(Cluster.created_at.asc(), Cluster.id.asc())
     )
-    cluster = result.scalars().first()
+    clusters = result.scalars().all()
+    if len(clusters) > 1:
+        raise BadRequestError("请先选择集群", "errors.cluster.id_required")
+    return clusters[0] if clusters else None
+
+
+async def _fetch_all_storage_classes(
+    db: AsyncSession, cluster_id: str | None, org_id: str,
+) -> list[StorageClassInfo]:
+    """从指定已连接集群获取全部 StorageClass。"""
+    cluster = await _resolve_storage_cluster(db, cluster_id, org_id)
     if not cluster:
         return []
 
@@ -81,15 +103,18 @@ async def _fetch_all_storage_classes(db: AsyncSession) -> list[StorageClassInfo]
 @router.get("", response_model=ApiResponse[list[StorageClassInfo]])
 async def list_storage_classes(
     scope: str = Query("allowed", description="allowed=仅启用的, all=全部"),
+    cluster_id: str | None = Query(None, description="目标集群 ID"),
     db: AsyncSession = Depends(get_db),
     _current_user: User = Depends(get_current_user),
+    org_ctx=Depends(get_current_org),
 ):
     """获取 StorageClass 列表。
 
     - scope=allowed（默认）: 仅返回管理员启用的 SC（部署页使用）
     - scope=all: 返回集群中全部 SC 并标记启用状态（设置页使用）
     """
-    all_scs = await _fetch_all_storage_classes(db)
+    _current_user, org = org_ctx
+    all_scs = await _fetch_all_storage_classes(db, cluster_id, org.id)
 
     if scope == "all":
         return ApiResponse(data=all_scs)

--- a/nodeskclaw-backend/tests/test_storage_cluster_scope.py
+++ b/nodeskclaw-backend/tests/test_storage_cluster_scope.py
@@ -1,0 +1,109 @@
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.api.storage import _resolve_storage_cluster
+from app.core.exceptions import BadRequestError, NotFoundError
+from app.models import Base
+from app.models.cluster import Cluster
+from app.models.organization import Organization
+from app.models.user import User
+
+TEST_DATABASE_URL = "postgresql+asyncpg://nodeskclaw:nodeskclaw@localhost:5432/nodeskclaw_test"
+
+engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+TestSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def setup_db():
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+    except Exception:
+        yield False
+        return
+
+    yield True
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+async def _seed_clusters(db: AsyncSession) -> tuple[str, str, str]:
+    suffix = uuid4().hex[:8]
+    org = Organization(id=f"org-storage-scope-{suffix}", name="Storage Scope Org", slug=f"storage-scope-org-{suffix}")
+    outsider_org = Organization(
+        id=f"org-storage-outsider-{suffix}", name="Outsider Org", slug=f"storage-scope-outsider-{suffix}",
+    )
+    user = User(
+        id=f"user-storage-scope-{suffix}",
+        name="Storage Scope User",
+        email=f"storage-scope-{suffix}@example.com",
+        username=f"storage-scope-{suffix}",
+        password_hash="x",
+    )
+    db.add_all([org, outsider_org, user])
+
+    cluster_a = Cluster(
+        id=f"cluster-storage-a-{suffix}",
+        name="Cluster A",
+        org_id=org.id,
+        created_by=user.id,
+        compute_provider="k8s",
+        status="connected",
+    )
+    cluster_b = Cluster(
+        id=f"cluster-storage-b-{suffix}",
+        name="Cluster B",
+        org_id=org.id,
+        created_by=user.id,
+        compute_provider="k8s",
+        status="connected",
+    )
+    outsider = Cluster(
+        id=f"cluster-storage-outsider-{suffix}",
+        name="Outsider Cluster",
+        org_id=outsider_org.id,
+        created_by=user.id,
+        compute_provider="k8s",
+        status="connected",
+    )
+    db.add_all([cluster_a, cluster_b, outsider])
+    await db.commit()
+    return org.id, cluster_a.id, outsider.id
+
+
+@pytest.mark.asyncio
+async def test_resolve_storage_cluster_requires_explicit_cluster_in_multi_cluster_org(setup_db):
+    if not setup_db:
+        pytest.skip("test database unavailable")
+
+    async with TestSessionLocal() as db:
+        org_id, _, _ = await _seed_clusters(db)
+
+        with pytest.raises(BadRequestError) as exc:
+            await _resolve_storage_cluster(db, None, org_id)
+
+        assert exc.value.message_key == "errors.cluster.id_required"
+
+
+@pytest.mark.asyncio
+async def test_resolve_storage_cluster_filters_by_org_and_cluster_id(setup_db):
+    if not setup_db:
+        pytest.skip("test database unavailable")
+
+    async with TestSessionLocal() as db:
+        org_id, cluster_id, outsider_cluster_id = await _seed_clusters(db)
+
+        cluster = await _resolve_storage_cluster(db, cluster_id, org_id)
+
+        assert cluster is not None
+        assert cluster.id == cluster_id
+
+        with pytest.raises(NotFoundError) as exc:
+            await _resolve_storage_cluster(db, outsider_cluster_id, org_id)
+
+        assert exc.value.message_key == "errors.cluster.not_found"

--- a/nodeskclaw-portal/src/i18n/locales/en-US.ts
+++ b/nodeskclaw-portal/src/i18n/locales/en-US.ts
@@ -1319,6 +1319,8 @@ const enUS = {
       member_not_found: "This user is not a member of the current organization",
     },
     cluster: {
+      id_required: "Please select a cluster first",
+      not_found: "Cluster not found",
       single_cluster_limit: "A cluster is already configured. Only one cluster is supported.",
       docker_cli_not_found: "Docker CLI not installed. Please set up Docker per the deployment guide.",
       docker_socket_unavailable: "Cannot connect to Docker. Ensure Docker Desktop or Docker daemon is running.",

--- a/nodeskclaw-portal/src/i18n/locales/zh-CN.ts
+++ b/nodeskclaw-portal/src/i18n/locales/zh-CN.ts
@@ -1319,6 +1319,8 @@ const zhCN = {
       member_not_found: "该用户不是当前组织的成员",
     },
     cluster: {
+      id_required: "请先选择集群",
+      not_found: "集群不存在",
       single_cluster_limit: "已配置集群，当前仅支持单集群",
       docker_cli_not_found: "Docker CLI 未安装，请参照部署文档配置 Docker 环境",
       docker_socket_unavailable: "无法连接 Docker，请确认 Docker Desktop 或 Docker daemon 正在运行",

--- a/nodeskclaw-portal/src/views/CreateInstance.vue
+++ b/nodeskclaw-portal/src/views/CreateInstance.vue
@@ -123,6 +123,19 @@ function addProvider(p: string) {
   newProviderOpen.value = false
 }
 
+async function loadStorageClasses(clusterId: string) {
+  const scRes = await api.get('/storage-classes', {
+    params: {
+      scope: 'all',
+      cluster_id: clusterId,
+    },
+  })
+  const items = (scRes.data.data ?? []) as StorageClassItem[]
+  storageClasses.value = items
+  const def = items.find(sc => sc.is_default)
+  selectedStorageClass.value = def ? def.name : (items[0]?.name ?? null)
+}
+
 function addCustomProvider() {
   const slug = customSlug.value.trim()
   if (!slug) return
@@ -342,13 +355,10 @@ onMounted(async () => {
       selectedRuntime.value = engines.value[0].runtime_id
     }
     clusters.value = (clustersRes.data.data ?? []).filter((c: any) => c.status === 'connected')
-    if (isK8sCluster.value) {
+    const activeCluster = clusters.value[0]
+    if (activeCluster?.compute_provider === 'k8s') {
       try {
-        const scRes = await api.get('/storage-classes?scope=all')
-        const items = (scRes.data.data ?? []) as StorageClassItem[]
-        storageClasses.value = items
-        const def = items.find(sc => sc.is_default)
-        selectedStorageClass.value = def ? def.name : (items[0]?.name ?? null)
+        await loadStorageClasses(activeCluster.id)
       } catch {
         // StorageClass 列表获取失败不阻塞创建流程
       }


### PR DESCRIPTION
## Summary
- stop `/storage-classes` from implicitly reading the first connected cluster in the org
- keep single-cluster callers working, but require explicit selection once multiple connected K8s clusters exist
- pass `cluster_id` from the portal create flow and add regression coverage for cluster resolution

## Verification
- `cd nodeskclaw-backend && uv run ruff check app/api/storage.py tests/test_storage_cluster_scope.py`
- `cd nodeskclaw-backend && uv run pytest tests/test_storage_cluster_scope.py` *(skipped locally: `nodeskclaw_test` unavailable)*
- `cd nodeskclaw-portal && npm exec -- vue-tsc -b`

Closes #155