### PR TITLE
fix(events): 统一最近事件响应契约

### DIFF
--- a/nodeskclaw-backend/app/api/events.py
+++ b/nodeskclaw-backend/app/api/events.py
@@ -7,12 +7,14 @@ import json
 import logging
 
 from fastapi import APIRouter, Depends, Query
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_db
 from app.core.security import get_current_user
 from app.models.user import User
+from app.schemas.common import ApiResponse
 from app.services import cluster_service
 from app.services.k8s.k8s_client import K8sClient
 from app.services.runtime.registries.compute_registry import require_k8s_client
@@ -23,6 +25,19 @@ router = APIRouter()
 
 WATCH_TIMEOUT_SECONDS = 1800
 HEARTBEAT_INTERVAL_SECONDS = 15
+
+
+class RecentEventItem(BaseModel):
+    type: str
+    event_type: str
+    reason: str | None = None
+    message: str | None = None
+    involved: str | None = None
+    involved_kind: str | None = None
+    namespace: str | None = None
+    count: int | None = None
+    last_timestamp: str | None = None
+    first_timestamp: str | None = None
 
 
 def _map_k8s_event(obj, event_type: str = "OBJECT") -> dict:
@@ -45,7 +60,7 @@ def _map_k8s_event(obj, event_type: str = "OBJECT") -> dict:
     }
 
 
-@router.get("/recent")
+@router.get("/recent", response_model=ApiResponse[list[RecentEventItem]])
 async def events_recent(
     cluster_id: str = Query(..., description="集群 ID"),
     namespace: str = Query("", description="命名空间，留空则查询所有"),
@@ -56,7 +71,7 @@ async def events_recent(
     cluster = await cluster_service.get_cluster(cluster_id, db)
 
     if not cluster.is_k8s:
-        return JSONResponse({"data": []})
+        return ApiResponse(data=[])
 
     k8s = await require_k8s_client(cluster)
 
@@ -68,7 +83,7 @@ async def events_recent(
     items = [_map_k8s_event(obj) for obj in resp.items]
     items.sort(key=lambda e: e["last_timestamp"] or "", reverse=True)
 
-    return JSONResponse({"data": items[:limit]})
+    return ApiResponse(data=items[:limit])
 
 
 @router.get("/stream")

--- a/nodeskclaw-backend/app/api/portal/events.py
+++ b/nodeskclaw-backend/app/api/portal/events.py
@@ -7,10 +7,12 @@ import json
 import logging
 
 from fastapi import APIRouter, Depends, Query
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import get_current_org, get_db
+from app.schemas.common import ApiResponse
 from app.services import cluster_service
 from app.services.k8s.k8s_client import K8sClient
 from app.services.runtime.registries.compute_registry import require_k8s_client
@@ -21,6 +23,19 @@ router = APIRouter()
 
 WATCH_TIMEOUT_SECONDS = 1800
 HEARTBEAT_INTERVAL_SECONDS = 15
+
+
+class RecentEventItem(BaseModel):
+    type: str
+    event_type: str
+    reason: str | None = None
+    message: str | None = None
+    involved: str | None = None
+    involved_kind: str | None = None
+    namespace: str | None = None
+    count: int | None = None
+    last_timestamp: str | None = None
+    first_timestamp: str | None = None
 
 
 def _map_k8s_event(obj, event_type: str = "OBJECT") -> dict:
@@ -43,7 +58,7 @@ def _map_k8s_event(obj, event_type: str = "OBJECT") -> dict:
     }
 
 
-@router.get("/recent")
+@router.get("/recent", response_model=ApiResponse[list[RecentEventItem]])
 async def events_recent(
     cluster_id: str = Query(..., description="集群 ID"),
     namespace: str = Query("", description="命名空间，留空则查询所有"),
@@ -55,7 +70,7 @@ async def events_recent(
     cluster = await cluster_service.get_cluster(cluster_id, db, org.id)
 
     if not cluster.is_k8s:
-        return JSONResponse({"data": []})
+        return ApiResponse(data=[])
 
     k8s = await require_k8s_client(cluster)
 
@@ -67,7 +82,7 @@ async def events_recent(
     items = [_map_k8s_event(obj) for obj in resp.items]
     items.sort(key=lambda e: e["last_timestamp"] or "", reverse=True)
 
-    return JSONResponse({"data": items[:limit]})
+    return ApiResponse(data=items[:limit])
 
 
 @router.get("/stream")

--- a/nodeskclaw-backend/tests/test_events_response_contract.py
+++ b/nodeskclaw-backend/tests/test_events_response_contract.py
@@ -1,0 +1,110 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.core.security import get_current_user
+from app.main import app
+from app.models import Base
+from app.models.admin_membership import AdminMembership
+from app.models.organization import Organization
+from app.models.user import User
+
+TEST_DATABASE_URL = "postgresql+asyncpg://nodeskclaw:nodeskclaw@localhost:5432/nodeskclaw_test"
+
+engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+TestSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def setup_db():
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+    except Exception:
+        yield False
+        return
+
+    yield True
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.fixture
+async def admin_user(setup_db):
+    if not setup_db:
+        pytest.skip("test database unavailable")
+
+    suffix = uuid4().hex[:8]
+    org = Organization(id=f"org-events-{suffix}", name="Events Org", slug=f"events-org-{suffix}")
+    user = User(
+        id=f"user-events-{suffix}",
+        name="Events Admin",
+        email=f"events-{suffix}@example.com",
+        username=f"events-{suffix}",
+        password_hash="x",
+        current_org_id=org.id,
+    )
+    membership = AdminMembership(
+        id=f"admin-events-{suffix}",
+        user_id=user.id,
+        org_id=org.id,
+        role="member",
+    )
+    async with TestSessionLocal() as db:
+        db.add_all([org, user, membership])
+        await db.commit()
+    return user, org
+
+
+@pytest.mark.asyncio
+async def test_admin_events_recent_returns_api_response_for_non_k8s_cluster(client, admin_user):
+    user, _org = admin_user
+    app.dependency_overrides[get_current_user] = lambda: user
+    try:
+        with patch(
+            "app.api.events.cluster_service.get_cluster",
+            new=AsyncMock(return_value=SimpleNamespace(is_k8s=False)),
+        ):
+            response = await client.get("/api/v1/admin/events/recent", params={"cluster_id": "cluster-1"})
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "code": 0,
+        "error_code": None,
+        "message_key": None,
+        "message": "success",
+        "data": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_portal_events_recent_returns_api_response_for_non_k8s_cluster(client):
+    user = SimpleNamespace(id="user-portal")
+    org = SimpleNamespace(id="org-portal")
+    from app.core.deps import get_current_org
+
+    app.dependency_overrides[get_current_org] = lambda: (user, org)
+    try:
+        with patch(
+            "app.api.portal.events.cluster_service.get_cluster",
+            new=AsyncMock(return_value=SimpleNamespace(is_k8s=False)),
+        ):
+            response = await client.get("/api/v1/events/recent", params={"cluster_id": "cluster-1"})
+    finally:
+        app.dependency_overrides.pop(get_current_org, None)
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "code": 0,
+        "error_code": None,
+        "message_key": None,
+        "message": "success",
+        "data": [],
+    }


### PR DESCRIPTION
## Summary
- switch admin `/events/recent` and portal `/events/recent` to the unified `ApiResponse` contract
- keep the existing event payload shape intact while removing bare `JSONResponse` special cases
- add regression coverage for the recent-events response wrapper

## Verification
- `cd nodeskclaw-backend && uv run ruff check app/api/events.py app/api/portal/events.py tests/test_events_response_contract.py`
- `cd nodeskclaw-backend && uv run pytest tests/test_events_response_contract.py` *(1 passed, 1 skipped locally: admin-path case needs `nodeskclaw_test`)*

Closes #158
Closes #170