### PR TITLE
chore(openclaw): 升级 OpenClaw 至 2026.4.2

### DIFF
--- a/nodeskclaw-artifacts/openclaw-image/Dockerfile
+++ b/nodeskclaw-artifacts/openclaw-image/Dockerfile
@@ -10,8 +10,8 @@ ARG NODE_VERSION=22
 FROM node:${NODE_VERSION}-bookworm-slim
 
 # ---------- 构建参数 ----------
-ARG OPENCLAW_VERSION=2026.3.28
-ARG IMAGE_VERSION=v2026.3.28
+ARG OPENCLAW_VERSION=2026.4.2
+ARG IMAGE_VERSION=v2026.4.2
 
 # ---------- 元数据标签 ----------
 LABEL maintainer="Xy718Labs"


### PR DESCRIPTION
## OpenClaw 版本更新

| 项目 | 值 |
|------|-----|
| 当前版本 | `2026.3.28` |
| 最新版本 | `2026.4.2` |
| Release | https://github.com/openclaw/openclaw/releases/tag/v2026.4.2 |

### CHANGELOG 摘要

<details><summary>展开查看</summary>


### Breaking

- Plugins/xAI: move `x_search` settings from the legacy core `tools.web.x_search.*` path to the plugin-owned `plugins.entries.xai.config.xSearch.*` path, standardize `x_search` auth on `plugins.entries.xai.config.webSearch.apiKey` / `XAI_API_KEY`, and migrate legacy config with `openclaw doctor --fix`. (#59674) Thanks @vincentkoc.
- Plugins/web fetch: move Firecrawl `web_fetch` config from the legacy core `tools.web.fetch.firecrawl.*` path to the plugin-owned `plugins.entries.firecrawl.config.webFetch.*` path, route `web_fetch` fallback through the new fetch-provider boundary instead of a Firecrawl-only core branch, and migrate legacy config with `openclaw doctor --fix`. (#59465) Thanks @vincentkoc.

### Changes

- Tasks/Task Flow: restore the core Task Flow substrate with managed-vs-mirrored sync modes, durable flow state/revision tracking, and `openclaw flows` inspection/recovery primitives so background orchestration can persist and be operated separately from plugin authoring layers. (#58930) Thanks @mbelinky.
- Tasks/Task Flow: add managed child task spawning plus sticky cancel intent, so external orchestrators can stop scheduling immediately and let parent Task Flows settle to `cancelled` once active child tasks finish. (#59610) Thanks @mbelinky.
- Plugins/Task Flow: add a bound `api.runtime.taskFlow` seam so plugins and trusted authoring layers can create and drive managed Task Flows from host-resolved OpenClaw context without passing owner identifiers on each call. (#59622) Thanks @mbelinky.
- Android/assistant: add assistant-role entrypoints plus Google Assistant App Actions metadata so Android can launch OpenClaw from the assistant trigger and hand prompts into the chat composer. (#59596) Thanks @obviyus.
- Exec defaults: make gateway/node host exec default to YOLO mode by requesting `security=full` with `ask=off`, and align host approval-file fallbacks plus docs/doctor reporting with that no-prompt default.
- Providers/runtime: add provider

</details>

### 集成面检查清单

对照 `ee/docs/OpenClaw集成面清单.md`，逐项确认新版本兼容性：

- [ ] **配置 Schema** — `openclaw.json` Zod strict schema 是否接受我们写入的全部字段
- [ ] **文件系统路径** — `/root/.openclaw/` 目录结构是否变更
- [ ] **Session 文件格式** — `sessions.json` / `.jsonl` 结构是否变更
- [ ] **Channel Plugin SDK** — `openclaw/plugin-sdk` API 是否有 breaking change
- [ ] **Gateway 协议** — 端口 (18789/9721)、`/healthz`、认证方式是否变更
- [ ] **CLI 行为** — `openclaw gateway` 参数是否变更
- [ ] **Gene/Skill 注入** — `SKILL.md` 格式、`extraDirs` 机制是否变更
- [ ] **安全管道** — `tools.exec.*` 配置项、Security WebSocket 协议是否变更
- [ ] **镜像验证** — `./verify.sh <image:tag>` 全部 PASS

---

**此 PR 由 GitHub Actions 自动创建。**

合并后请：
1. 构建新镜像：`./build.sh openclaw --version 2026.4.2`
2. 运行验证：`./verify.sh <image:tag>`
3. 在引擎版本管理中发布新版本