### PR TITLE
wecom-bridge: add image recognition for Bug screenshot analysis

### DIFF
--- a/src/wecom-bridge/wework-chat-archive/chat-archive/auto_reply/agent/core.py
+++ b/src/wecom-bridge/wework-chat-archive/chat-archive/auto_reply/agent/core.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
+
+from database import get_setting
+from config import LLM_API_URL, LLM_API_KEY, LLM_MODEL
+from .base_skill import BaseSkill
+from .context import context_store
+
+logger = logging.getLogger(__name__)
+
+MAX_ITERATIONS = 5
+LLM_TIMEOUT = 60
+
+# Appended to the system prompt in group-chat contexts so the LLM knows how
+# to interpret [用户名] tags and [截图] markers stored in conversation history.
+GROUP_CONTEXT_SUPPLEMENT = """
+群聊中的消息带有 [用户名] 前缀标记，上下文中带 [截图] 标记的是用户之前发送的截图的文字描述。
+
+当用户 @你 提问时：
+1. 优先关注该用户自己发送的消息和截图（通过 [用户名] 匹配）
+2. 如果其他用户的消息与当前问题相关，也可以参考
+3. 结合截图描述理解问题全貌
+回复时简洁清晰，直接针对提问者的问题。"""
+
+
+def _cfg(key: str, fallback: str = "") -> str:
+    return get_setting(key, fallback)
+
+
+async def _call_llm(
+    messages: list[dict],
+    tools: list[dict] | None = None,
+    model: str = "",
+) -> dict:
+    api_url = _cfg("llm_api_url", LLM_API_URL)
+    api_key = _cfg("llm_api_key", LLM_API_KEY)
+    use_model = model or _cfg("llm_model", LLM_MODEL)
+
+    if not api_url or not api_key:
+        raise ValueError("LLM 未配置 (api_url / api_key)")
+
+    body: dict = {
+        "model": use_model,
+        "messages": messages,
+    }
+    if tools:
+        body["tools"] = tools
+
+    async with httpx.AsyncClient(timeout=LLM_TIMEOUT) as client:
+        resp = await client.post(
+            api_url,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=body,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def run_agent(
+    conversation_id: str,
+    user_message: str,
+    system_prompt: str,
+    skills: list[BaseSkill],
+    model: str = "",
+    sender_name: str = "",
+) -> tuple[str, str]:
+    """Execute the ReAct agent loop.
+
+    Returns (reply_text, skill_name_used).
+    """
+    tagged_message = f"[{sender_name}] {user_message}" if sender_name else user_message
+
+    effective_prompt = system_prompt
+    if sender_name:
+        effective_prompt = (system_prompt or "") + GROUP_CONTEXT_SUPPLEMENT
+
+    tools = [s.to_function_schema() for s in skills] if skills else None
+    messages = context_store.build_messages(
+        conversation_id, effective_prompt, tagged_message,
+    )
+
+    skill_used = ""
+    choice: dict = {}
+
+    for iteration in range(MAX_ITERATIONS):
+        logger.info(
+            "[agent] iter=%d msgs=%d tools=%d",
+            iteration + 1,
+            len(messages),
+            len(tools) if tools else 0,
+        )
+
+        result = await _call_llm(messages, tools, model)
+        choice = result["choices"][0]["message"]
+
+        tool_calls = choice.get("tool_calls")
+        if not tool_calls:
+            reply = choice.get("content", "").strip() or "..."
+            context_store.add(conversation_id, "user", tagged_message)
+            context_store.add(conversation_id, "assistant", reply)
+            return reply, skill_used
+
+        messages.append(choice)
+
+        for tc in tool_calls:
+            fn = tc["function"]
+            skill_name = fn["name"]
+
+            try:
+                args = json.loads(fn.get("arguments", "{}"))
+            except json.JSONDecodeError:
+                args = {}
+
+            logger.info("[agent] skill call: %s(%s)", skill_name, args)
+
+            skill = next((s for s in skills if s.name == skill_name), None)
+            if skill:
+                try:
+                    sr = await skill.execute(**args)
+                    tool_result = sr.content
+                    skill_used = skill_name
+                except Exception as e:
+                    logger.error("[agent] skill %s error: %s", skill_name, e)
+                    tool_result = f"Error executing skill: {e}"
+            else:
+                tool_result = f"Unknown skill: {skill_name}"
+
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc["id"],
+                "content": tool_result,
+            })
+
+    final = choice.get("content", "").strip() if choice else ""
+    reply = final or "抱歉，我暂时无法回答这个问题。"
+    context_store.add(conversation_id, "user", tagged_message)
+    context_store.add(conversation_id, "assistant", reply)
+    return reply, skill_used

--- a/src/wecom-bridge/wework-chat-archive/chat-archive/auto_reply/handler.py
+++ b/src/wecom-bridge/wework-chat-archive/chat-archive/auto_reply/handler.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+
+from . import service
+from .agent.core import run_agent
+from .agent.skill_registry import registry
+from .image_util import (
+    should_skip_by_metadata, describe_image,
+    mark_image_pending, mark_image_done, wait_for_pending_image,
+)
+from .models import AutoReplyLog
+from . import wework_api
+from database import SessionLocal, Message, get_setting, set_setting
+
+logger = logging.getLogger(__name__)
+
+NOTIFY_NEW_MSG = 11010
+NOTIFY_MEMBER_JOIN = 1002
+TEXT_CONTENT_TYPES = {0, 2}
+IMAGE_CONTENT_TYPES = {3, 14}  # 普通图片 + HD图片（不含贴纸 29）
+
+_bot_wxid: str | None = None
+
+
+def _get_bot_wxid() -> str:
+    """Get the bot's wxid, auto-detecting from sent messages if needed."""
+    global _bot_wxid
+    if _bot_wxid:
+        return _bot_wxid
+
+    wxid = get_setting("bot_wxid", "")
+    if wxid:
+        _bot_wxid = wxid
+        return wxid
+
+    db = SessionLocal()
+    try:
+        msg = db.query(Message).filter(Message.send_flag == 1).order_by(Message.id.desc()).first()
+        if msg and msg.sender:
+            _bot_wxid = msg.sender
+            set_setting("bot_wxid", msg.sender)
+            logger.info("[auto_reply] bot wxid auto-detected: %s", msg.sender)
+            return msg.sender
+    finally:
+        db.close()
+
+    return ""
+
+
+def _is_at_me(at_list_raw) -> bool:
+    bot_wxid = _get_bot_wxid()
+    if not bot_wxid:
+        return False
+    at_list = at_list_raw
+    if isinstance(at_list, str):
+        try:
+            at_list = json.loads(at_list)
+        except (json.JSONDecodeError, TypeError):
+            return False
+    if not isinstance(at_list, list):
+        return False
+    return bot_wxid in at_list
+
+
+import re
+
+_AT_PATTERN = re.compile(r'@\S+\s*')
+
+
+def _strip_at_bot(content: str) -> str:
+    """Remove the first @mention from the message content."""
+    cleaned = _AT_PATTERN.sub('', content, count=1).strip()
+    return cleaned
+
+
+async def process(payload: dict) -> bool:
+    """Process a webhook payload for auto-reply.
+
+    Returns True if handled (caller should skip forwarding).
+    """
+    notify_type = payload.get("notify_type")
+
+    if notify_type == NOTIFY_MEMBER_JOIN:
+        return await _handle_member_join(payload)
+    elif notify_type == NOTIFY_NEW_MSG:
+        return await _handle_new_message(payload)
+    return False
+
+
+async def _handle_member_join(payload: dict) -> bool:
+    data = payload.get("data", {})
+    room_id = str(data.get("room_id", ""))
+    members = str(data.get("members", ""))
+
+    if not room_id or not members:
+        return False
+
+    config = service.get_config(room_id)
+    if not config or not config.welcome_enabled:
+        return False
+
+    member_list = [m.strip() for m in members.split(",") if m.strip()]
+    welcome_msg = config.welcome_message or "欢迎 {name} 加入群聊！"
+    content = welcome_msg.replace("{name}", "{$@}")
+    conversation_id = f"R:{room_id}"
+
+    try:
+        await wework_api.send_room_at(conversation_id, content, member_list)
+        logger.info("[auto_reply] welcome sent [%s] @%s", room_id, member_list)
+        _log_reply(room_id, "", "", welcome_msg, content, "welcome", "", 0)
+        return True
+    except Exception as e:
+        logger.error("[auto_reply] welcome failed: %s", e, exc_info=True)
+        return False
+
+
+async def _handle_new_message(payload: dict) -> bool:
+    data = payload.get("data", {})
+    sender = str(data.get("sender", ""))
+    room_id = str(data.get("roomid", "0"))
+    content = str(data.get("content", ""))
+    content_type = data.get("content_type", 0)
+    referid = str(data.get("referid", "0"))
+    sender_name = data.get("sender_name", "")
+    send_flag = data.get("send_flag", 0)
+    at_list = data.get("at_list", [])
+
+    is_dm = (room_id == "0")
+
+    if is_dm:
+        global_config = service.get_config("")
+        if not global_config or not getattr(global_config, "dm_enabled", False):
+            return False
+
+    is_image = content_type in IMAGE_CONTENT_TYPES
+    if content_type not in TEXT_CONTENT_TYPES and not is_image:
+        return False
+    # Image replies (referid != "0") are allowed — users often reply with screenshots
+    if referid != "0" and not is_image:
+        return False
+    if send_flag == 1:
+        return False
+    if not is_image and not content.strip():
+        return False
+
+    if is_dm:
+        config = service.get_config("")
+    else:
+        config = service.get_config(room_id)
+    if not config or not config.reply_enabled:
+        return False
+
+    conversation_id = f"DM:{sender}" if is_dm else f"R:{room_id}"
+
+    # ── Image processing path (before require_at / cooldown) ──────────
+    if is_image:
+        if should_skip_by_metadata(data):
+            return False
+
+        mark_image_pending(room_id, sender)
+        try:
+            description = await describe_image(data)
+        finally:
+            mark_image_done(room_id, sender)
+
+        if not description:
+            return False
+
+        image_text = f"[截图] {description}"
+        tagged_image = f"[{sender_name}] {image_text}" if sender_name else image_text
+
+        if is_dm:
+            # DM: fall through to agent reply below
+            content = f"[用户发送了截图] {description}"
+        elif config and config.require_at:
+            # Group + require_at: silently add to context, don't reply
+            from .agent.context import context_store
+            context_store.add(conversation_id, "user", tagged_image)
+            logger.info("[auto_reply] image description stored in context [%s]", room_id)
+            return True
+        else:
+            # Group + no require_at: "analyzing" hint then agent reply
+            # Hint is sent AFTER SKIP check — no false promises
+            try:
+                await wework_api.send_room_at(
+                    conversation_id, "{$@} 正在分析截图，请稍候...", [sender],
+                )
+            except Exception:
+                pass
+            content = f"[用户发送了截图] {description}"
+        # fall through to keyword / AI reply logic
+    # ── End image path ──────────────────────────────────────────────────
+
+    clean_content = content.strip() if is_dm else _strip_at_bot(content)
+    tagged = f"[{sender_name}] {clean_content}" if sender_name else clean_content
+
+    should_reply = True
+    if not is_dm and not is_image and config.require_at and not _is_at_me(at_list):
+        from .agent.context import context_store
+        if tagged.strip():
+            context_store.add(conversation_id, "user", tagged)
+        should_reply = False
+
+    if not should_reply:
+        return False
+
+    # @bot text: wait for any pending image from the same sender before proceeding
+    if not is_dm and not is_image:
+        waited = await wait_for_pending_image(room_id, sender)
+        if waited:
+            logger.info("[auto_reply] waited for pending image [%s/%s]", room_id, sender)
+
+    cooldown_key = sender if is_dm else room_id
+    if not service.check_cooldown(cooldown_key, sender, config.cooldown_seconds):
+        logger.debug("[auto_reply] cooldown active %s/%s", cooldown_key, sender)
+        return False
+
+    start_time = time.time()
+    reply_text = ""
+    reply_type = ""
+    skill_used = ""
+
+    try:
+        if config.reply_mode in ("keyword", "ai"):
+            rules = service.get_rules("" if is_dm else room_id)
+            matched = service.match_keyword(content, rules)
+            if matched:
+                reply_text = matched.reply_content
+                reply_type = "keyword"
+
+        if not reply_text and config.reply_mode == "ai":
+            enabled_skills = service.get_enabled_skill_names("" if is_dm else room_id)
+            skills = registry.get_enabled(enabled_skills)
+            system_prompt = config.ai_system_prompt or ""
+            model = config.ai_model or ""
+
+            reply_text, skill_used = await run_agent(
+                conversation_id, clean_content, system_prompt, skills, model,
+                sender_name=sender_name if not is_dm else "",
+            )
+            reply_type = "ai"
+
+        if not reply_text:
+            return False
+
+        if is_dm:
+            await wework_api.send_text(f"S:{sender}", reply_text)
+        else:
+            await wework_api.send_room_at(
+                conversation_id, f"{{$@}} {reply_text}", [sender],
+            )
+
+        latency = int((time.time() - start_time) * 1000)
+        log_room = "DM" if is_dm else room_id
+        logger.info(
+            "[auto_reply] replied [%s] %s -> %s (%dms)",
+            log_room, content[:50], reply_text[:50], latency,
+        )
+        _log_reply(
+            log_room, sender, sender_name,
+            content, reply_text,
+            reply_type, skill_used, latency,
+        )
+        return True
+
+    except Exception as e:
+        logger.error("[auto_reply] message handling failed: %s", e, exc_info=True)
+        return False
+
+
+def _log_reply(
+    room_id: str,
+    sender: str,
+    sender_name: str,
+    trigger: str,
+    reply: str,
+    reply_type: str,
+    skill_used: str,
+    latency_ms: int,
+):
+    try:
+        db = SessionLocal()
+        db.add(AutoReplyLog(
+            room_id=room_id,
+            sender=sender,
+            sender_name=sender_name,
+            trigger_message=trigger,
+            reply_content=reply,
+            reply_type=reply_type,
+            skill_used=skill_used,
+            latency_ms=latency_ms,
+        ))
+        db.commit()
+        db.close()
+    except Exception as e:
+        logger.error("[auto_reply] log write failed: %s", e)

--- a/src/wecom-bridge/wework-chat-archive/chat-archive/auto_reply/image_util.py
+++ b/src/wecom-bridge/wework-chat-archive/chat-archive/auto_reply/image_util.py
@@ -1,0 +1,285 @@
+"""Image download, intent classification, description, and pending-image tracking.
+
+Two-layer filtering:
+  Layer 1 (free): webhook metadata pre-filter (dimensions, size, direct_url)
+  Layer 2 (1 LLM call): Vision LLM classifies + describes in a single request
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+
+import httpx
+
+from config import APP_KEY, APP_SECRET, GUID, API_GATEWAY, LLM_API_URL, LLM_API_KEY, LLM_MODEL
+from database import get_setting
+
+logger = logging.getLogger(__name__)
+
+MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5 MB
+DOWNLOAD_TIMEOUT = 30
+LLM_VISION_TIMEOUT = 60
+PENDING_IMAGE_WAIT_TIMEOUT = 15.0
+
+MIN_IMAGE_WIDTH = 200
+MIN_IMAGE_HEIGHT = 200
+MIN_IMAGE_SIZE = 20 * 1024  # 20 KB
+
+SKIP_TOKEN = "SKIP"
+
+IMAGE_CLASSIFY_AND_DESCRIBE_PROMPT = """\
+请先判断这张图片的类型，然后根据判断结果执行不同操作：
+
+## 判断规则
+如果图片属于以下任一类别，请直接回复"SKIP"（只回复这四个字母，不要其他内容）：
+- 表情包、贴纸、GIF 动图
+- 聊天截图中无明显问题的日常对话
+- 风景照、自拍、食物照片等生活图片
+- 广告、二维码、营销海报
+- 无法识别内容的模糊图片
+
+## 描述规则
+如果图片是以下类型，请用中文描述你看到的内容：
+- 软件/网页的 Bug 截图、报错界面、异常状态
+- 用户操作遇到问题的截图
+- 包含错误提示或异常信息的界面
+
+描述时重点关注：
+1. 界面上的错误提示、报错信息
+2. 用户正在操作的功能和当前状态
+3. 任何异常的 UI 元素或行为
+用简洁的一段话描述，不要分析原因，只描述你看到了什么。"""
+
+
+# ---------------------------------------------------------------------------
+# Pending-image tracker
+# ---------------------------------------------------------------------------
+
+_pending_images: dict[tuple[str, str], asyncio.Event] = {}
+
+
+def mark_image_pending(room_id: str, sender: str) -> None:
+    _pending_images[(room_id, sender)] = asyncio.Event()
+
+
+def mark_image_done(room_id: str, sender: str) -> None:
+    event = _pending_images.pop((room_id, sender), None)
+    if event:
+        event.set()
+
+
+async def wait_for_pending_image(room_id: str, sender: str) -> bool:
+    """Block until the sender's pending image finishes (max *PENDING_IMAGE_WAIT_TIMEOUT* s).
+
+    Returns True if a pending image was awaited and completed, False otherwise.
+    """
+    event = _pending_images.get((room_id, sender))
+    if not event:
+        return False
+    try:
+        await asyncio.wait_for(event.wait(), PENDING_IMAGE_WAIT_TIMEOUT)
+        return True
+    except asyncio.TimeoutError:
+        _pending_images.pop((room_id, sender), None)
+        logger.warning("[image] pending image wait timed out (%s, %s)", room_id, sender)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — metadata pre-filter (zero cost)
+# ---------------------------------------------------------------------------
+
+def should_skip_by_metadata(data: dict) -> bool:
+    """Return True when the image is almost certainly a sticker / emoji / icon."""
+    # direct_url typically means sticker / emoji downloaded directly
+    if data.get("url"):
+        return True
+
+    cdn = data.get("cdn", {})
+    w = cdn.get("image_width") or data.get("width", 0)
+    h = cdn.get("image_height") or data.get("height", 0)
+    size = cdn.get("size", 0)
+
+    if w and h and (w < MIN_IMAGE_WIDTH or h < MIN_IMAGE_HEIGHT):
+        logger.debug("[image] dimensions too small (%dx%d), skip", w, h)
+        return True
+    if 0 < size < MIN_IMAGE_SIZE:
+        logger.debug("[image] file too small (%d B), skip", size)
+        return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Image download (JuheBot API)
+# ---------------------------------------------------------------------------
+
+def _extract_file_id(data: dict) -> tuple[str, bool]:
+    """Extract (file_id, is_hd) from webhook payload data."""
+    cdn = data.get("cdn", {})
+    if cdn and cdn.get("file_id"):
+        return cdn["file_id"], cdn.get("is_hd", False)
+
+    content = data.get("content", "")
+    if content and content.startswith(("30", "*", "https://")):
+        return content.strip(), False
+
+    for key in ("file_id", "fileid", "fileId"):
+        if data.get(key):
+            return str(data[key]), False
+
+    return "", False
+
+
+def _mime_from_content_type(ct: str) -> str:
+    if "png" in ct:
+        return "image/png"
+    if "gif" in ct:
+        return "image/gif"
+    if "webp" in ct:
+        return "image/webp"
+    return "image/jpeg"
+
+
+async def fetch_image_bytes(data: dict) -> tuple[bytes, str] | None:
+    """Download the image and return *(raw_bytes, mime_type)* or ``None``.
+
+    Silently returns None on missing credentials, download failure, or oversized
+    images — never raises.
+    """
+    if not APP_KEY or not APP_SECRET:
+        logger.debug("[image] JuheBot credentials missing, skip download")
+        return None
+
+    file_id, is_hd = _extract_file_id(data)
+    if not file_id:
+        logger.debug("[image] no file_id in payload, skip")
+        return None
+
+    try:
+        async with httpx.AsyncClient(timeout=DOWNLOAD_TIMEOUT) as client:
+            # Direct CDN URL (e.g. wework.qpic.cn)
+            if file_id.startswith("https://wework.qpic.cn"):
+                resp = await client.get(file_id)
+                if resp.status_code == 200:
+                    mime = _mime_from_content_type(resp.headers.get("content-type", ""))
+                    return resp.content, mime
+                return None
+
+            # Determine JuheBot API path
+            if file_id.startswith("30"):
+                api_path = "/cloud/c2c_download"
+                file_type = 1 if is_hd else 2
+            elif file_id.startswith("*"):
+                api_path = "/cloud/big_download"
+                file_type = 2
+            elif file_id.startswith("https://"):
+                api_path = "/cloud/wx_download"
+                file_type = 2
+            else:
+                api_path = "/cloud/c2c_download"
+                file_type = 1 if is_hd else 2
+
+            resp = await client.post(API_GATEWAY, json={
+                "app_key": APP_KEY,
+                "app_secret": APP_SECRET,
+                "path": api_path,
+                "data": {"guid": GUID, "file_id": file_id, "file_type": file_type},
+            })
+            result = resp.json()
+
+            if result.get("error_code") != 0:
+                logger.warning("[image] CDN download failed file_id=%s: %s",
+                               file_id[:40], result.get("error_message"))
+                return None
+
+            download_url = (
+                result.get("data", {}).get("file_url", "")
+                or result.get("data", {}).get("url", "")
+                or result.get("data", {}).get("download_url", "")
+            )
+            if not download_url:
+                logger.warning("[image] no download URL for file_id=%s", file_id[:40])
+                return None
+
+            file_resp = await client.get(download_url)
+            if file_resp.status_code == 200:
+                mime = _mime_from_content_type(file_resp.headers.get("content-type", ""))
+                return file_resp.content, mime
+
+    except Exception as e:
+        logger.error("[image] fetch_image_bytes error file_id=%s: %s", file_id[:40], e)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — Vision LLM classify + describe (single call)
+# ---------------------------------------------------------------------------
+
+def _llm_cfg(key: str, fallback: str) -> str:
+    return get_setting(key, fallback)
+
+
+async def describe_image(data: dict) -> str | None:
+    """Download an image, then ask a Vision LLM to classify and describe it.
+
+    Returns a text description for Bug screenshots, or ``None`` for irrelevant
+    images (SKIP), download failures, or LLM errors.  Never raises.
+    """
+    try:
+        result = await fetch_image_bytes(data)
+        if not result:
+            return None
+
+        img_bytes, mime = result
+        if len(img_bytes) > MAX_IMAGE_BYTES:
+            logger.warning("[image] image too large (%.1f MB), skip",
+                           len(img_bytes) / 1024 / 1024)
+            return None
+
+        b64 = base64.b64encode(img_bytes).decode()
+        data_uri = f"data:{mime};base64,{b64}"
+
+        api_url = _llm_cfg("llm_api_url", LLM_API_URL)
+        api_key = _llm_cfg("llm_api_key", LLM_API_KEY)
+        model = _llm_cfg("llm_model", LLM_MODEL)
+
+        if not api_url or not api_key:
+            logger.warning("[image] LLM not configured, skip describe")
+            return None
+
+        body = {
+            "model": model,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": data_uri}},
+                    {"type": "text", "text": IMAGE_CLASSIFY_AND_DESCRIBE_PROMPT},
+                ],
+            }],
+        }
+
+        async with httpx.AsyncClient(timeout=LLM_VISION_TIMEOUT) as client:
+            resp = await client.post(
+                api_url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=body,
+            )
+            resp.raise_for_status()
+            reply = resp.json()["choices"][0]["message"]["content"].strip()
+
+        if reply.upper().startswith(SKIP_TOKEN):
+            logger.info("[image] LLM classified as irrelevant, SKIP")
+            return None
+
+        logger.info("[image] LLM description: %s", reply[:80])
+        return reply
+
+    except Exception as e:
+        logger.error("[image] describe_image error: %s", e, exc_info=True)
+        return None


### PR DESCRIPTION
## Summary

- 在 chat-archive 的 auto_reply 模块新增图片理解能力，支持对企微群聊中的 Bug 截图进行自动分析
- 两层过滤机制：元数据预筛（尺寸/大小，零成本）+ Vision LLM 单次调用（意图判断+描述）
- pending-image 追踪器（asyncio.Event）解决用户发截图后立即 @bot 的竞态条件

## Changes

- **新建 `image_util.py`**：元数据预筛 + JuheBot API 图片下载 + Vision LLM 意图分类/描述 + pending_images 追踪器
- **修改 `handler.py`**：放宽 content_type/referid 过滤、图片静默入上下文、@bot 时等待 pending 图片、"正在分析"提示后置到 SKIP 判断之后
- **修改 `agent/core.py`**：群聊场景自动追加 GROUP_CONTEXT_SUPPLEMENT 到 system prompt，引导 LLM 识别 [用户名] 和 [截图] 标记

## Test plan

- [ ] 竞态场景：发截图 → 3 秒后 @bot → 验证 bot 等待截图处理完再回复
- [ ] 正常场景：发截图 → 15 秒后 @bot → 回复包含截图分析
- [ ] 引用回复：引用 bot 消息发截图 → 不被 referid 过滤
- [ ] require_at=False：Bug 截图确认有效后才发"正在分析"；表情包/无关照片无任何回复
- [ ] 多消息碎片化：发截图 + 发文字 + @bot → 回复综合所有信息
- [ ] 过滤：表情包/贴纸静默跳过，无关照片 LLM SKIP 静默跳过
- [ ] DM：私聊发截图 → 直接回复分析结果
- [ ] 兼容：纯文本消息原有功能不受影响

Made with [Cursor](https://cursor.com)