### PR TITLE
fix(workspace): 收口默认定时计划文案

### DIFF
--- a/nodeskclaw-backend/app/services/workspace_defaults.py
+++ b/nodeskclaw-backend/app/services/workspace_defaults.py
@@ -1,0 +1,5 @@
+DEFAULT_WORKSPACE_SCHEDULE_NAME = "Routine Check"
+DEFAULT_WORKSPACE_SCHEDULE_MESSAGE = (
+    "Check the blackboard todo queue, pick the highest-priority task, execute it, and report progress."
+)
+LEGACY_WORKSPACE_SCHEDULE_NAMES = ["任务巡检", "定时巡检", DEFAULT_WORKSPACE_SCHEDULE_NAME]

--- a/nodeskclaw-backend/app/services/workspace_service.py
+++ b/nodeskclaw-backend/app/services/workspace_service.py
@@ -23,6 +23,10 @@ from app.models.workspace_objective import WorkspaceObjective
 from app.models.workspace_schedule import WorkspaceSchedule
 from app.models.workspace_task import WorkspaceTask
 from app.services import storage_service
+from app.services.workspace_defaults import (
+    DEFAULT_WORKSPACE_SCHEDULE_MESSAGE,
+    DEFAULT_WORKSPACE_SCHEDULE_NAME,
+)
 from app.services.runtime import node_card as node_card_service
 from app.schemas.workspace import (
     AddAgentRequest,
@@ -123,9 +127,9 @@ async def create_workspace(db: AsyncSession, org_id: str, user_id: str, data: Wo
 
     schedule = WorkspaceSchedule(
         workspace_id=ws.id,
-        name="定时巡检",
+        name=DEFAULT_WORKSPACE_SCHEDULE_NAME,
         cron_expr="0 */4 * * *",
-        message_template="请检查黑板待办任务队列，接取并执行优先级最高的任务。完成后汇报进展。",
+        message_template=DEFAULT_WORKSPACE_SCHEDULE_MESSAGE,
         is_active=False,
     )
     db.add(schedule)

--- a/nodeskclaw-backend/app/startup/seed.py
+++ b/nodeskclaw-backend/app/startup/seed.py
@@ -437,6 +437,12 @@ async def seed_default_required_genes(
 
 
 async def _ensure_workspace_schedules(session_factory: async_sessionmaker[AsyncSession]) -> None:
+    from app.services.workspace_defaults import (
+        DEFAULT_WORKSPACE_SCHEDULE_MESSAGE,
+        DEFAULT_WORKSPACE_SCHEDULE_NAME,
+        LEGACY_WORKSPACE_SCHEDULE_NAMES,
+    )
+
     async with session_factory() as db:
         from app.models.workspace import Workspace
         from app.models.workspace_schedule import WorkspaceSchedule
@@ -449,16 +455,16 @@ async def _ensure_workspace_schedules(session_factory: async_sessionmaker[AsyncS
             existing = (await db.execute(
                 select(WorkspaceSchedule).where(
                     WorkspaceSchedule.workspace_id == ws.id,
-                    WorkspaceSchedule.name.in_(["任务巡检", "定时巡检"]),
+                    WorkspaceSchedule.name.in_(LEGACY_WORKSPACE_SCHEDULE_NAMES),
                     WorkspaceSchedule.deleted_at.is_(None),
                 ).order_by(WorkspaceSchedule.created_at.desc())
             )).scalars().first()
             if existing is None:
                 db.add(WorkspaceSchedule(
                     workspace_id=ws.id,
-                    name="定时巡检",
+                    name=DEFAULT_WORKSPACE_SCHEDULE_NAME,
                     cron_expr="0 */4 * * *",
-                    message_template="请检查黑板待办任务队列，接取并执行优先级最高的任务。完成后汇报进展。",
+                    message_template=DEFAULT_WORKSPACE_SCHEDULE_MESSAGE,
                     is_active=False,
                 ))
         await db.commit()

--- a/nodeskclaw-backend/tests/test_workspace_default_schedule.py
+++ b/nodeskclaw-backend/tests/test_workspace_default_schedule.py
@@ -1,0 +1,74 @@
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.models.organization import Organization
+from app.models.user import User
+from app.models.workspace_schedule import WorkspaceSchedule
+from app.schemas.workspace import WorkspaceCreate
+from app.services.workspace_defaults import (
+    DEFAULT_WORKSPACE_SCHEDULE_MESSAGE,
+    DEFAULT_WORKSPACE_SCHEDULE_NAME,
+)
+from app.services.workspace_service import create_workspace
+
+TEST_DATABASE_URL = "postgresql+asyncpg://nodeskclaw:nodeskclaw@localhost:5432/nodeskclaw_test"
+
+engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+TestSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def setup_db():
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+    except Exception:
+        yield False
+        return
+
+    yield True
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_uses_neutral_default_schedule_copy(setup_db):
+    if not setup_db:
+        pytest.skip("test database unavailable")
+
+    suffix = uuid4().hex[:8]
+    async with TestSessionLocal() as db:
+        org = Organization(id=f"org-workspace-{suffix}", name="Workspace Org", slug=f"workspace-org-{suffix}")
+        user = User(
+            id=f"user-workspace-{suffix}",
+            name="Workspace User",
+            email=f"workspace-{suffix}@example.com",
+            username=f"workspace-{suffix}",
+            password_hash="x",
+        )
+        db.add_all([org, user])
+        await db.commit()
+
+        workspace = await create_workspace(
+            db,
+            org.id,
+            user.id,
+            WorkspaceCreate(name="Workspace", description="", color="#000000", icon="bot"),
+        )
+
+        result = await db.execute(
+            select(WorkspaceSchedule).where(
+                WorkspaceSchedule.workspace_id == workspace.id,
+                WorkspaceSchedule.deleted_at.is_(None),
+            )
+        )
+        schedule = result.scalar_one()
+
+        assert schedule.name == DEFAULT_WORKSPACE_SCHEDULE_NAME
+        assert schedule.message_template == DEFAULT_WORKSPACE_SCHEDULE_MESSAGE


### PR DESCRIPTION
## Summary
- replace the hard-coded Chinese default workspace schedule copy with a shared neutral template
- reuse the same defaults in both workspace creation and startup backfill
- add regression coverage for the default schedule seed values

## Verification
- `cd nodeskclaw-backend && uv run ruff check app/services/workspace_defaults.py app/services/workspace_service.py app/startup/seed.py tests/test_workspace_default_schedule.py`
- `cd nodeskclaw-backend && uv run pytest tests/test_workspace_default_schedule.py` *(skipped locally: `nodeskclaw_test` unavailable)*

Closes #169