### PR TITLE
fix(docker): 修复 Docker Compose 部署时配置模板丢失问题

### DIFF
--- a/nodeskclaw-backend/app/services/runtime/compute/docker_provider.py
+++ b/nodeskclaw-backend/app/services/runtime/compute/docker_provider.py
@@ -141,7 +141,7 @@ async def _seed_template_from_image(config: InstanceComputeConfig, data_dir: Pat
 
     try:
         proc = await asyncio.create_subprocess_exec(
-            "docker", "create", "--name", tmp_container, image,
+            "docker", "create", "--platform", "linux/amd64", "--name", tmp_container, image,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )


### PR DESCRIPTION
Docker Compose 部署时，空目录 bind mount 到容器 /root/.openclaw 会 遮盖镜像内预置的 openclaw.json.template，导致 entrypoint 以无配置 模式启动。通过 docker create + cp 在容器启动前从镜像提取模板文件
到宿主机 data 目录，仅首次部署时执行，已有/迁移实例不受影响。
