### PR TITLE
fix(docker): Docker Compose 部署时从镜像提取配置模板

### DIFF
--- a/nodeskclaw-backend/app/services/runtime/compute/docker_provider.py
+++ b/nodeskclaw-backend/app/services/runtime/compute/docker_provider.py
@@ -7,7 +7,8 @@ import json
 import logging
 import os
 import re
-from pathlib import PurePosixPath, PureWindowsPath
+import uuid
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 from app.services.docker_constants import DOCKER_DATA_DIR, DOCKER_HOST_DATA_DIR
 from app.services.runtime.compute.base import (
@@ -116,6 +117,68 @@ def _resolve_compose_path(slug: str, stored_path: str) -> str:
     return current_path
 
 
+async def _seed_template_from_image(config: InstanceComputeConfig, data_dir: Path) -> None:
+    """从镜像中提取配置模板到宿主机 data 目录（仅首次部署时需要）。
+
+    Docker Compose 部署时，空目录 bind mount 到容器的 data_dir 会遮盖镜像内
+    预置的模板文件。此处通过 docker create + cp 从镜像提取模板，确保 entrypoint
+    首次启动时能正确生成 openclaw.json。
+    """
+    from app.services.runtime.registries.runtime_registry import RUNTIME_REGISTRY
+    rt_spec = RUNTIME_REGISTRY.get(config.runtime)
+    if not rt_spec:
+        return
+
+    container_data_dir = rt_spec.data_dir_container_path
+    template_rel = "openclaw.json.template"
+    host_template = data_dir / template_rel
+
+    # 已存在则跳过（已有实例或已迁移数据）
+    if host_template.exists():
+        return
+
+    image = config.env_vars.get("DOCKER_IMAGE", f"deskclaw:{config.image_version}")
+    tmp_container = f"tmpl-seed-{config.slug}-{uuid.uuid4().hex[:8]}"
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "docker", "create", "--platform", "linux/amd64", "--name", tmp_container, image,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            logger.warning("seed_template: docker create failed: %s", stderr.decode().strip()[:300])
+            return
+        container_id = stdout.decode().strip()
+        if not container_id:
+            logger.warning("seed_template: docker create returned empty id for %s", config.slug)
+            return
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "docker", "cp",
+                f"{container_id}:{container_data_dir}/{template_rel}",
+                str(host_template),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, cp_stderr = await proc.communicate()
+            if proc.returncode != 0:
+                logger.warning("seed_template: docker cp failed: %s", cp_stderr.decode().strip()[:300])
+                return
+            logger.info("seed_template: copied %s from %s to %s", template_rel, image, host_template)
+        finally:
+            rm_proc = await asyncio.create_subprocess_exec(
+                "docker", "rm", container_id,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            await rm_proc.wait()
+    except Exception:
+        logger.warning("seed_template: unexpected error for %s", config.slug, exc_info=True)
+
+
 def _build_compose_yaml(config: InstanceComputeConfig) -> dict:
     """Generate a docker-compose service definition with full resource config."""
     env = {
@@ -201,6 +264,9 @@ class DockerComputeProvider:
         os.makedirs(project_dir, exist_ok=True)
         data_dir = DOCKER_DATA_DIR / config.slug / "data"
         os.makedirs(str(data_dir), exist_ok=True)
+
+        # 从镜像中提取模板文件到宿主机 data 目录，确保 entrypoint 首次启动能生成配置
+        await _seed_template_from_image(config, data_dir)
 
         compose = _build_compose_yaml(config)
         compose_path = _compose_path_for_slug(config.slug)


### PR DESCRIPTION
Docker Compose 部署时，空目录 bind mount 到容器 /root/.openclaw 会 遮盖镜像内预置的 openclaw.json.template，导致 entrypoint 以无配置 模式启动。通过 docker create + cp 在容器启动前从镜像提取模板文件
到宿主机 data 目录，仅首次部署时执行，已有/迁移实例不受影响。