### PR TITLE
fix(docker): 修复 Docker 首次部署缺少配置模板

### DIFF
--- a/nodeskclaw-backend/app/services/runtime/compute/docker_provider.py
+++ b/nodeskclaw-backend/app/services/runtime/compute/docker_provider.py
@@ -129,8 +129,11 @@ async def _seed_template_from_image(config: InstanceComputeConfig, data_dir: Pat
     if not rt_spec:
         return
 
+    template_rel = rt_spec.docker_seed_template_rel
+    if not template_rel:
+        return
+
     container_data_dir = rt_spec.data_dir_container_path
-    template_rel = "openclaw.json.template"
     host_template = data_dir / template_rel
 
     # 已存在则跳过（已有实例或已迁移数据）

--- a/nodeskclaw-backend/app/services/runtime/registries/runtime_registry.py
+++ b/nodeskclaw-backend/app/services/runtime/registries/runtime_registry.py
@@ -38,6 +38,7 @@ class RuntimeSpec:
     has_init_script: bool = True
     available: bool = True
     docker_command: tuple[str, ...] | None = None
+    docker_seed_template_rel: str | None = None
     backup_dirs: tuple[str, ...] = ()
     backup_exclude_patterns: tuple[str, ...] = (
         "node_modules", "dist", "__pycache__", ".git", "cache", "*.pyc",
@@ -86,6 +87,7 @@ def _register_builtins() -> None:
         display_powered_by="OpenClaw",
         readiness_probe_path="/readyz",
         order=0,
+        docker_seed_template_rel="openclaw.json.template",
         backup_dirs=(".openclaw", ".deskclaw/tools"),
     ))
     RUNTIME_REGISTRY.register(RuntimeSpec(

--- a/nodeskclaw-backend/tests/test_docker_provider_paths.py
+++ b/nodeskclaw-backend/tests/test_docker_provider_paths.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.services.runtime.compute import docker_provider
+from app.services.runtime.registries.runtime_registry import RuntimeSpec
 
 
 def test_join_host_path_for_posix() -> None:
@@ -100,3 +101,92 @@ async def test_destroy_instance_falls_back_to_slug_cleanup(monkeypatch) -> None:
         ("docker", "rm", "-f", "demo"),
         ("docker", "network", "rm", "demo-net"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_seed_template_from_image_uses_runtime_template_rel(tmp_path, monkeypatch) -> None:
+    calls = []
+
+    class _Proc:
+        def __init__(self, returncode: int = 0, stdout: bytes = b"", stderr: bytes = b""):
+            self.returncode = returncode
+            self._stdout = stdout
+            self._stderr = stderr
+
+        async def communicate(self):
+            return self._stdout, self._stderr
+
+        async def wait(self):
+            return self.returncode
+
+    async def _fake_exec(*args, **kwargs):
+        calls.append(args)
+        if args[:2] == ("docker", "create"):
+            return _Proc(stdout=b"cid-123\n")
+        return _Proc()
+
+    monkeypatch.setattr(docker_provider.asyncio, "create_subprocess_exec", _fake_exec)
+
+    config = docker_provider.InstanceComputeConfig(
+        instance_id="instance-1",
+        name="demo",
+        namespace="default",
+        slug="demo",
+        image_version="latest",
+        runtime="openclaw",
+        gateway_port=3000,
+        env_vars={},
+        mem_limit=None,
+        cpu_limit=None,
+        companion=None,
+    )
+
+    await docker_provider._seed_template_from_image(config, tmp_path)
+
+    create_call = calls[0]
+    assert calls == [
+        ("docker", "create", "--platform", "linux/amd64", "--name", create_call[5], "deskclaw:latest"),
+        ("docker", "cp", f"cid-123:/root/.openclaw/openclaw.json.template", str(tmp_path / "openclaw.json.template")),
+        ("docker", "rm", "cid-123"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_seed_template_from_image_skips_runtime_without_template(tmp_path, monkeypatch) -> None:
+    calls = []
+
+    async def _fake_exec(*args, **kwargs):
+        calls.append(args)
+        raise AssertionError("should not invoke docker when runtime has no seed template")
+
+    monkeypatch.setattr(docker_provider.asyncio, "create_subprocess_exec", _fake_exec)
+
+    from app.services.runtime.registries.runtime_registry import RUNTIME_REGISTRY
+
+    monkeypatch.setattr(
+        RUNTIME_REGISTRY,
+        "get",
+        lambda runtime_id: RuntimeSpec(
+            runtime_id=runtime_id,
+            data_dir_container_path="/root/.custom",
+            docker_seed_template_rel=None,
+        ),
+    )
+
+    config = docker_provider.InstanceComputeConfig(
+        instance_id="instance-1",
+        name="demo",
+        namespace="default",
+        slug="demo",
+        image_version="latest",
+        runtime="custom",
+        gateway_port=3000,
+        env_vars={},
+        mem_limit=None,
+        cpu_limit=None,
+        companion=None,
+    )
+
+    await docker_provider._seed_template_from_image(config, tmp_path)
+
+    assert calls == []


### PR DESCRIPTION
## Summary

- 保留社区 PR #183 的原作者修复，首次部署时从镜像预种配置模板
- 将模板预种逻辑改为运行时感知，不再写死 OpenClaw 模板名
- 补 Docker provider 单测，覆盖需要预种和无需预种两条分支

## Test plan

- [x] `cd nodeskclaw-backend && uv run pytest tests/test_docker_provider_paths.py`
- [x] `cd nodeskclaw-backend && uv run ruff check app/services/runtime/compute/docker_provider.py app/services/runtime/registries/runtime_registry.py tests/test_docker_provider_paths.py`

Closes #186
Supersedes #183