### PR TITLE
fix(api): 统一工作区部署错误响应协议

### DIFF
--- a/nodeskclaw-backend/app/api/workspace_deploys.py
+++ b/nodeskclaw-backend/app/api/workspace_deploys.py
@@ -26,6 +26,13 @@ def _ok(data=None, message: str = "success"):
     return {"code": 0, "message": message, "data": data}
 
 
+def _error(status_code: int, error_code: int, message_key: str, message: str) -> HTTPException:
+    return HTTPException(
+        status_code=status_code,
+        detail={"error_code": error_code, "message_key": message_key, "message": message},
+    )
+
+
 @router.get("/deploys/active")
 async def list_active_deploys(
     org_ctx=Depends(get_current_org),
@@ -85,7 +92,7 @@ async def get_workspace_deploy(
     )
     row = r.first()
     if not row:
-        raise HTTPException(status_code=404, detail="部署记录不存在")
+        raise _error(404, 40461, "errors.workspace_deploy.not_found", "部署记录不存在")
     wd, ws_name = row
     return _ok({
         "id": wd.id,
@@ -119,7 +126,7 @@ async def workspace_deploy_progress_stream(
         )
     )
     if not r.scalar_one_or_none():
-        raise HTTPException(status_code=404, detail="部署记录不存在")
+        raise _error(404, 40461, "errors.workspace_deploy.not_found", "部署记录不存在")
 
     async def generate():
         async for ev in event_bus.subscribe("workspace_deploy_progress"):

--- a/nodeskclaw-backend/tests/test_workspace_deploy_error_contract.py
+++ b/nodeskclaw-backend/tests/test_workspace_deploy_error_contract.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.deps import get_current_org, get_db
+from app.main import app
+
+
+def _make_db_override(fake_db):
+    async def override_db():
+        yield fake_db
+
+    return override_db
+
+
+@pytest.mark.asyncio
+async def test_get_workspace_deploy_not_found_returns_unified_error(client):
+    fake_db = AsyncMock()
+    fake_db.execute.return_value = SimpleNamespace(first=lambda: None)
+    app.dependency_overrides[get_current_org] = lambda: (
+        SimpleNamespace(id="user-1"), SimpleNamespace(id="org-1"),
+    )
+    app.dependency_overrides[get_db] = _make_db_override(fake_db)
+    try:
+        response = await client.get("/api/v1/workspaces/deploys/deploy-missing")
+    finally:
+        app.dependency_overrides.pop(get_current_org, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "code": 40461,
+        "error_code": 40461,
+        "message_key": "errors.workspace_deploy.not_found",
+        "message": "部署记录不存在",
+        "data": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_workspace_deploy_progress_not_found_returns_unified_error(client):
+    fake_db = AsyncMock()
+    fake_db.execute.return_value = SimpleNamespace(scalar_one_or_none=lambda: None)
+    app.dependency_overrides[get_current_org] = lambda: (
+        SimpleNamespace(id="user-1"), SimpleNamespace(id="org-1"),
+    )
+    app.dependency_overrides[get_db] = _make_db_override(fake_db)
+    try:
+        response = await client.get("/api/v1/workspaces/deploys/deploy-missing/progress")
+    finally:
+        app.dependency_overrides.pop(get_current_org, None)
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "code": 40461,
+        "error_code": 40461,
+        "message_key": "errors.workspace_deploy.not_found",
+        "message": "部署记录不存在",
+        "data": None,
+    }

--- a/nodeskclaw-portal/src/i18n/locales/en-US.ts
+++ b/nodeskclaw-portal/src/i18n/locales/en-US.ts
@@ -1608,6 +1608,9 @@ const enUS = {
       ingress_base_domain_hint: "This requires organization admin configuration.",
       ingress_base_domain_go_configure: "Go to Network Routing settings",
     },
+    workspace_deploy: {
+      not_found: "Deployment record not found",
+    },
     storage: {
       not_configured: "File storage service is not configured",
       presign_failed: "Failed to generate file download link, please try again later",

--- a/nodeskclaw-portal/src/i18n/locales/zh-CN.ts
+++ b/nodeskclaw-portal/src/i18n/locales/zh-CN.ts
@@ -1608,6 +1608,9 @@ const zhCN = {
       ingress_base_domain_hint: "此配置需要组织管理员完成。",
       ingress_base_domain_go_configure: "前往网络路由配置",
     },
+    workspace_deploy: {
+      not_found: "部署记录不存在",
+    },
     storage: {
       not_configured: "文件存储服务未配置",
       presign_failed: "生成文件下载链接失败，请稍后重试",


### PR DESCRIPTION
## 说明
- 将工作区模板部署详情和进度接口的 404 返回改成统一错误协议
- 为 `errors.workspace_deploy.not_found` 补齐 i18n 词条
- 增加不依赖数据库的契约测试，覆盖详情接口和进度接口的 404 响应

## 验证
- `cd nodeskclaw-backend && uv run ruff check app/api/workspace_deploys.py tests/test_workspace_deploy_error_contract.py`
- `cd nodeskclaw-backend && uv run pytest tests/test_workspace_deploy_error_contract.py`
- `cd nodeskclaw-portal && npm exec -- vue-tsc -b`

Closes #192