### PR TITLE
fix(backend): 修复基因回调地址解析

### DIFF
--- a/nodeskclaw-backend/app/api/trust.py
+++ b/nodeskclaw-backend/app/api/trust.py
@@ -186,11 +186,11 @@ async def submit_approval_request(
     db.add(record)
     await db.commit()
 
-    from app.core.config import settings
+    from app.core.config import get_nodeskclaw_webhook_base_url, settings
 
     workspace_name = ws.name if ws else body.workspace_id
 
-    callback_base = getattr(settings, "NODESKCLAW_WEBHOOK_BASE_URL", "") or getattr(settings, "NODESKCLAW_HOST", "") or ""
+    callback_base = get_nodeskclaw_webhook_base_url()
     callback_url = f"{callback_base}/api/v1/workspaces/approval-requests/{record.id}/resolve"
 
     for ep in human_endpoints:

--- a/nodeskclaw-backend/app/core/config.py
+++ b/nodeskclaw-backend/app/core/config.py
@@ -4,6 +4,7 @@ import logging
 import re
 import socket
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -109,6 +110,7 @@ class Settings(BaseSettings):
     VKE_SUBNET_ID: str = ""
 
     # ── LLM Proxy ─────────────────────────────────────────
+    NODESKCLAW_WEBHOOK_BASE_URL: str = ""  # AI 员工回调后端的基础地址，如 http://nodeskclaw-backend:4510
     NODESKCLAW_HOST: str = ""  # 外部可达域名，如 https://nodeskclaw.example.com（废弃，保留兼容）
     LLM_PROXY_URL: str = ""  # 独立 LLM Proxy 服务外部地址，如 https://llm-proxy.example.com
     LLM_PROXY_INTERNAL_URL: str = ""  # K8s 集群内网地址，用于 openclaw.json 中的 baseUrl（绕过 ALB）
@@ -157,3 +159,29 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+def _strip_api_path(base_url: str) -> str:
+    parsed = urlsplit(base_url.rstrip("/"))
+    if not parsed.scheme or not parsed.netloc:
+        return base_url.rstrip("/")
+    path = parsed.path.rstrip("/")
+    for suffix in ("/api/v1", "/api"):
+        if path.endswith(suffix):
+            path = path[: -len(suffix)]
+            break
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", "")).rstrip("/")
+
+
+def get_nodeskclaw_webhook_base_url(cfg: Settings | None = None) -> str:
+    active_settings = cfg or settings
+    candidates = [
+        getattr(active_settings, "NODESKCLAW_WEBHOOK_BASE_URL", ""),
+        getattr(active_settings, "NODESKCLAW_HOST", ""),
+        _strip_api_path(getattr(active_settings, "AGENT_API_BASE_URL", "")),
+    ]
+    for candidate in candidates:
+        normalized = candidate.rstrip("/") if candidate else ""
+        if normalized:
+            return normalized
+    return ""

--- a/nodeskclaw-backend/app/services/gene_service.py
+++ b/nodeskclaw-backend/app/services/gene_service.py
@@ -13,7 +13,7 @@ from urllib.parse import urlencode
 from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
+from app.core.config import get_nodeskclaw_webhook_base_url, settings
 from app.core.exceptions import AppException, BadRequestError, ConflictError, NotFoundError
 from app.models.base import not_deleted
 from app.models.corridor import HumanHex
@@ -1375,7 +1375,7 @@ async def _send_learning_task(
         skill = manifest.get("skill", {})
         learning = manifest.get("learning")
 
-        callback_base = settings.NODESKCLAW_WEBHOOK_BASE_URL or ""
+        callback_base = get_nodeskclaw_webhook_base_url()
         callback_url = build_gene_callback_url(
             callback_base,
             "/api/v1/genes/learning-callback",
@@ -2068,7 +2068,7 @@ async def trigger_gene_creation(
 
     task_id = str(uuid.uuid4())
 
-    callback_base = settings.NODESKCLAW_WEBHOOK_BASE_URL or ""
+    callback_base = get_nodeskclaw_webhook_base_url()
     callback_url = build_gene_callback_url(
         callback_base,
         "/api/v1/genes/creation-callback",
@@ -2419,7 +2419,7 @@ async def _send_forgetting_task(
         manifest = _json_loads(gene.manifest) or {}
         skill_content = manifest.get("skill", {}).get("content", "")
 
-        callback_base = settings.NODESKCLAW_WEBHOOK_BASE_URL or ""
+        callback_base = get_nodeskclaw_webhook_base_url()
         callback_url = build_gene_callback_url(
             callback_base,
             "/api/v1/genes/forgetting-callback",

--- a/nodeskclaw-backend/app/services/llm_config_service.py
+++ b/nodeskclaw-backend/app/services/llm_config_service.py
@@ -15,7 +15,7 @@ from urllib.parse import urlparse as _urlparse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
+from app.core.config import get_nodeskclaw_webhook_base_url, settings
 from app.core.exceptions import AppException, BadRequestError
 from app.models.base import not_deleted
 from app.models.cluster import Cluster
@@ -974,7 +974,7 @@ def _inject_learning_channel_config(
     if "channels" not in config:
         config["channels"] = {}
 
-    callback_base = getattr(settings, "NODESKCLAW_WEBHOOK_BASE_URL", "") or ""
+    callback_base = get_nodeskclaw_webhook_base_url()
 
     config["channels"]["learning"] = {
         "accounts": {

--- a/nodeskclaw-backend/tests/test_gene_callback_signature.py
+++ b/nodeskclaw-backend/tests/test_gene_callback_signature.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.api import genes as genes_api
+from app.core.config import get_nodeskclaw_webhook_base_url
 from app.core.exceptions import BadRequestError
 from app.schemas.gene import LearningCallbackPayload
 from app.services.gene_service import (
@@ -35,6 +36,24 @@ def test_build_gene_callback_url_includes_signature_and_instance():
 
     assert "instance_id=inst-1" in url
     assert "sig=" in url
+
+
+def test_get_nodeskclaw_webhook_base_url_prefers_dedicated_setting():
+    class DummySettings:
+        NODESKCLAW_WEBHOOK_BASE_URL = "http://callback.internal/"
+        NODESKCLAW_HOST = "https://public.example.com"
+        AGENT_API_BASE_URL = "http://backend:4510/api/v1"
+
+    assert get_nodeskclaw_webhook_base_url(DummySettings()) == "http://callback.internal"
+
+
+def test_get_nodeskclaw_webhook_base_url_falls_back_to_agent_api_base():
+    class DummySettings:
+        NODESKCLAW_WEBHOOK_BASE_URL = ""
+        NODESKCLAW_HOST = ""
+        AGENT_API_BASE_URL = "http://backend:4510/api/v1/"
+
+    assert get_nodeskclaw_webhook_base_url(DummySettings()) == "http://backend:4510"
 
 
 def test_validate_gene_callback_auth_allows_legacy_unsigned_callback(monkeypatch):


### PR DESCRIPTION
## 变更说明

修复 `Issue #199` 暴露的基因回调地址解析问题，并把同源逻辑一并收敛：

- 在 `Settings` 中补充 `NODESKCLAW_WEBHOOK_BASE_URL` 配置项
- 新增统一的 callback base 解析函数，按 `NODESKCLAW_WEBHOOK_BASE_URL -> NODESKCLAW_HOST -> AGENT_API_BASE_URL` 回退
- 从 `AGENT_API_BASE_URL` 回退时自动去掉 `/api/v1`，避免生成 `/api/v1/api/v1/...` 的错误地址
- gene 的 create / learn / forget 三条回调链路统一改用该解析逻辑
- learning channel 配置注入、approval request callback 也同步切到同一套解析逻辑
- 补充 gene callback 相关单测，覆盖 dedicated setting 优先级和 `AGENT_API_BASE_URL` 回退

## 验证

- `uv run ruff check app/core/config.py app/services/gene_service.py app/services/llm_config_service.py app/api/trust.py tests/test_gene_callback_signature.py`
- `DEBUG=true DATABASE_URL=postgresql+asyncpg://nodeskclaw:nodeskclaw@localhost:5432/nodeskclaw_test uv run pytest tests/test_gene_callback_signature.py`

Closes #199