### PR TITLE
fix(backend): 修复模板一键部署过道缺失及 Docker 实例 tunnel 连接失败

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -282,7 +282,7 @@ _LLM_PROXY_DB_URL=$(cd "$BACKEND_DIR" && uv run python3 -c "from app.core.config
   2>&1 | prefix_output "$CYAN" "llm-prx" &
 PIDS+=($!)
 
-(cd "$BACKEND_DIR" && uv run uvicorn app.main:app --reload --port 4510 --timeout-graceful-shutdown 3) \
+(cd "$BACKEND_DIR" && uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 4510 --timeout-graceful-shutdown 3) \
   2>&1 | prefix_output "$BLUE" "backend" &
 PIDS+=($!)
 

--- a/nodeskclaw-backend/app/api/blackboard.py
+++ b/nodeskclaw-backend/app/api/blackboard.py
@@ -2,8 +2,6 @@
 
 import logging
 
-from typing import Optional
-
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -325,8 +323,8 @@ async def upload_file_multipart(
     workspace_id: str,
     file: UploadFile,
     parent_path: str = Form("/"),
-    filename: Optional[str] = Form(None),
-    content_type: Optional[str] = Form(None),
+    filename: str | None = Form(None),
+    content_type: str | None = Form(None),
     db: AsyncSession = Depends(get_db),
     user=Depends(_get_current_user_or_agent_dep()),
 ):

--- a/nodeskclaw-backend/app/api/corridors.py
+++ b/nodeskclaw-backend/app/api/corridors.py
@@ -282,8 +282,6 @@ async def delete_corridor_hex(
     user, org = org_ctx
     await _check_workspace(workspace_id, org, db)
     await wm_service.check_workspace_access(workspace_id, user, "edit_topology", db)
-    from app.models.node_card import NodeCard
-
     result = await db.execute(
         select(CorridorHex).where(
             CorridorHex.id == hex_id,

--- a/nodeskclaw-backend/app/api/corridors.py
+++ b/nodeskclaw-backend/app/api/corridors.py
@@ -282,6 +282,8 @@ async def delete_corridor_hex(
     user, org = org_ctx
     await _check_workspace(workspace_id, org, db)
     await wm_service.check_workspace_access(workspace_id, user, "edit_topology", db)
+    from app.models.node_card import NodeCard
+
     result = await db.execute(
         select(CorridorHex).where(
             CorridorHex.id == hex_id,
@@ -290,8 +292,15 @@ async def delete_corridor_hex(
         )
     )
     ch = result.scalar_one_or_none()
-    if not ch:
+
+    card = await node_card_service.get_node_card(db, node_id=hex_id, workspace_id=workspace_id)
+
+    if not ch and not card:
         raise _corridor_http_error(404, 40480, "errors.corridor.hex_not_found", "走廊格子不存在")
+
+    hex_q = card.hex_q if card else ch.hex_q
+    hex_r = card.hex_r if card else ch.hex_r
+    deleted_id = hex_id
 
     conns = await db.execute(
         select(HexConnection).where(
@@ -299,22 +308,25 @@ async def delete_corridor_hex(
             HexConnection.auto_created.is_(True),
             not_deleted(HexConnection),
             (
-                ((HexConnection.hex_a_q == ch.hex_q) & (HexConnection.hex_a_r == ch.hex_r))
-                | ((HexConnection.hex_b_q == ch.hex_q) & (HexConnection.hex_b_r == ch.hex_r))
+                ((HexConnection.hex_a_q == hex_q) & (HexConnection.hex_a_r == hex_r))
+                | ((HexConnection.hex_b_q == hex_q) & (HexConnection.hex_b_r == hex_r))
             ),
         )
     )
     for conn in conns.scalars().all():
         conn.soft_delete()
 
-    ch.soft_delete()
-    await node_card_service.soft_delete_node_card(db, node_id=ch.id, workspace_id=workspace_id)
+    if ch:
+        ch.soft_delete()
+    if card:
+        card.soft_delete()
+
     await db.commit()
     actor_type, actor_id = _actor(org_ctx)
-    broadcast_event(workspace_id, "corridor:hex_removed", {"hex_id": ch.id})
+    broadcast_event(workspace_id, "corridor:hex_removed", {"hex_id": deleted_id})
     await hooks.emit(
         "topology_change", db=db, workspace_id=workspace_id,
-        action="corridor_hex_deleted", target_type="corridor_hex", target_id=ch.id,
+        action="corridor_hex_deleted", target_type="corridor_hex", target_id=deleted_id,
         actor_type=actor_type, actor_id=actor_id,
     )
     return _ok(message="deleted")
@@ -605,10 +617,17 @@ async def delete_human_hex(
         )
     )
     hh = result.scalar_one_or_none()
-    if not hh:
+
+    card = await node_card_service.get_node_card(db, node_id=hex_id, workspace_id=workspace_id)
+
+    if not hh and not card:
         raise _corridor_http_error(404, 40483, "errors.corridor.human_hex_not_found", "人工节点不存在")
-    hh.soft_delete()
-    await node_card_service.soft_delete_node_card(db, node_id=hh.id, workspace_id=workspace_id)
+
+    if hh:
+        hh.soft_delete()
+    if card:
+        card.soft_delete()
+
     await db.commit()
     actor_type, actor_id = _actor(org_ctx)
     broadcast_event(workspace_id, "human:hex_removed", {"hex_id": hex_id})

--- a/nodeskclaw-backend/app/services/workspace_service.py
+++ b/nodeskclaw-backend/app/services/workspace_service.py
@@ -228,6 +228,61 @@ async def _apply_template_to_workspace(
     await db.commit()
 
 
+async def apply_internal_deploy_topology(
+    db: AsyncSession,
+    workspace_id: str,
+    user_id: str,
+    topo_snap: dict,
+    human_specs: list[dict],
+) -> None:
+    """Apply filtered topology snapshot (corridors, connections, human hexes) during template deploy."""
+    import uuid
+
+    from app.models.corridor import CorridorHex, HexConnection, HumanHex, ordered_pair
+
+    for node in topo_snap.get("nodes", []):
+        if node.get("node_type") == "corridor":
+            db.add(CorridorHex(
+                id=str(uuid.uuid4()),
+                workspace_id=workspace_id,
+                hex_q=node.get("hex_q", 0),
+                hex_r=node.get("hex_r", 0),
+                display_name=node.get("display_name", ""),
+                created_by=user_id,
+            ))
+
+    for spec in human_specs:
+        db.add(HumanHex(
+            id=str(uuid.uuid4()),
+            workspace_id=workspace_id,
+            user_id=spec.get("user_id", user_id),
+            hex_q=spec.get("hex_q", 0),
+            hex_r=spec.get("hex_r", 0),
+            display_name=spec.get("display_name"),
+            display_color=spec.get("display_color", "#f59e0b"),
+            created_by=user_id,
+        ))
+
+    await db.flush()
+
+    for edge in topo_snap.get("edges", []):
+        aq, ar, bq, br = ordered_pair(
+            edge.get("a_q", 0), edge.get("a_r", 0),
+            edge.get("b_q", 0), edge.get("b_r", 0),
+        )
+        db.add(HexConnection(
+            id=str(uuid.uuid4()),
+            workspace_id=workspace_id,
+            hex_a_q=aq, hex_a_r=ar,
+            hex_b_q=bq, hex_b_r=br,
+            direction=edge.get("direction", "both"),
+            auto_created=edge.get("auto_created", False),
+            created_by=user_id,
+        ))
+
+    await db.commit()
+
+
 async def list_workspaces(
     db: AsyncSession, org_id: str, user_id: str | None = None,
 ) -> list[WorkspaceListItem]:

--- a/nodeskclaw-backend/app/services/workspace_service.py
+++ b/nodeskclaw-backend/app/services/workspace_service.py
@@ -5,6 +5,7 @@ import base64
 import logging
 import re
 from collections.abc import Sequence
+from datetime import datetime
 from typing import Coroutine, Literal
 
 from sqlalchemy import and_, case, func, or_, select
@@ -167,9 +168,9 @@ async def _apply_template_to_workspace(
     import uuid
 
     from app.models.base import not_deleted
-    from app.models.corridor import HexConnection, ordered_pair
-    from app.models.node_card import NodeCard
+    from app.models.corridor import CorridorHex, HexConnection, ordered_pair
     from app.models.workspace_template import WorkspaceTemplate
+    from app.services.runtime import node_card as node_card_service
 
     result = await db.execute(
         select(WorkspaceTemplate).where(
@@ -187,17 +188,24 @@ async def _apply_template_to_workspace(
 
     for node in topo.get("nodes", []):
         if node.get("node_type") == "corridor":
-            db.add(NodeCard(
-                node_type="corridor",
-                node_id=str(uuid.uuid4()),
+            ch = CorridorHex(
+                id=str(uuid.uuid4()),
                 workspace_id=workspace_id,
                 hex_q=node.get("hex_q", 0),
                 hex_r=node.get("hex_r", 0),
-                name=node.get("display_name", ""),
-                status="active",
-                tags=[],
-                metadata_={},
-            ))
+                display_name=node.get("display_name", ""),
+                created_by=user_id,
+            )
+            db.add(ch)
+            await node_card_service.create_node_card(
+                db,
+                node_type="corridor",
+                node_id=ch.id,
+                workspace_id=workspace_id,
+                hex_q=ch.hex_q,
+                hex_r=ch.hex_r,
+                name=ch.display_name or "",
+            )
 
     await db.flush()
 
@@ -239,46 +247,65 @@ async def apply_internal_deploy_topology(
 ) -> None:
     """Apply filtered topology snapshot (corridors, connections, human hexes) during template deploy.
 
-    Writes directly to node_cards (Runtime v2) instead of legacy corridor_hexes/human_hexes,
-    because _build_hex_map short-circuits when node_cards already has data (agents are
-    already written there by add_agent).
+    Dual-writes to legacy tables (corridor_hexes/human_hexes) AND node_cards so that
+    existing CRUD endpoints and _is_hex_occupied checks keep working while _build_hex_map
+    (which short-circuits on node_cards) also sees the data.
     """
     import uuid
 
-    from app.models.corridor import HexConnection, ordered_pair
-    from app.models.node_card import NodeCard
+    from app.models.corridor import CorridorHex, HexConnection, HumanHex, ordered_pair
+    from app.services.runtime import node_card as node_card_service
 
     for node in topo_snap.get("nodes", []):
         if node.get("node_type") == "corridor":
-            db.add(NodeCard(
-                node_type="corridor",
-                node_id=str(uuid.uuid4()),
+            ch = CorridorHex(
+                id=str(uuid.uuid4()),
                 workspace_id=workspace_id,
                 hex_q=node.get("hex_q", 0),
                 hex_r=node.get("hex_r", 0),
-                name=node.get("display_name", ""),
-                status="active",
-                tags=[],
-                metadata_={},
-            ))
+                display_name=node.get("display_name", ""),
+                created_by=user_id,
+            )
+            db.add(ch)
+            await node_card_service.create_node_card(
+                db,
+                node_type="corridor",
+                node_id=ch.id,
+                workspace_id=workspace_id,
+                hex_q=ch.hex_q,
+                hex_r=ch.hex_r,
+                name=ch.display_name or "",
+            )
 
     for spec in human_specs:
-        db.add(NodeCard(
-            node_type="human",
-            node_id=spec.get("user_id", user_id),
+        hh = HumanHex(
+            id=str(uuid.uuid4()),
             workspace_id=workspace_id,
+            user_id=user_id,
             hex_q=spec.get("hex_q", 0),
             hex_r=spec.get("hex_r", 0),
+            display_name=spec.get("display_name", ""),
+            display_color=spec.get("display_color", "#f59e0b"),
+            channel_type=spec.get("channel_type"),
+            channel_config=spec.get("channel_config"),
+            created_by=user_id,
+        )
+        db.add(hh)
+        await node_card_service.create_node_card(
+            db,
+            node_type="human",
+            node_id=hh.id,
+            workspace_id=workspace_id,
+            hex_q=hh.hex_q,
+            hex_r=hh.hex_r,
             name=spec.get("display_name", ""),
-            status="active",
-            tags=[],
-            metadata_={
-                "user_id": spec.get("user_id", user_id),
+            metadata={
+                "user_id": user_id,
                 "display_color": spec.get("display_color", "#f59e0b"),
                 "channel_type": spec.get("channel_type"),
                 "channel_config": spec.get("channel_config"),
             },
-        ))
+        )
 
     await db.flush()
 
@@ -1187,7 +1214,7 @@ async def create_task(
     db: AsyncSession, workspace_id: str, data: TaskCreate,
     created_by_instance_id: str | None = None,
     schedule_id: str | None = None,
-    deadline: "datetime | None" = None,
+    deadline: datetime | None = None,
 ) -> TaskInfo:
     task = WorkspaceTask(
         workspace_id=workspace_id,

--- a/nodeskclaw-backend/app/services/workspace_service.py
+++ b/nodeskclaw-backend/app/services/workspace_service.py
@@ -167,7 +167,8 @@ async def _apply_template_to_workspace(
     import uuid
 
     from app.models.base import not_deleted
-    from app.models.corridor import CorridorHex, HexConnection, ordered_pair
+    from app.models.corridor import HexConnection, ordered_pair
+    from app.models.node_card import NodeCard
     from app.models.workspace_template import WorkspaceTemplate
 
     result = await db.execute(
@@ -186,15 +187,17 @@ async def _apply_template_to_workspace(
 
     for node in topo.get("nodes", []):
         if node.get("node_type") == "corridor":
-            ch = CorridorHex(
-                id=str(uuid.uuid4()),
+            db.add(NodeCard(
+                node_type="corridor",
+                node_id=str(uuid.uuid4()),
                 workspace_id=workspace_id,
                 hex_q=node.get("hex_q", 0),
                 hex_r=node.get("hex_r", 0),
-                display_name=node.get("display_name", ""),
-                created_by=user_id,
-            )
-            db.add(ch)
+                name=node.get("display_name", ""),
+                status="active",
+                tags=[],
+                metadata_={},
+            ))
 
     await db.flush()
 
@@ -203,7 +206,7 @@ async def _apply_template_to_workspace(
             edge.get("a_q", 0), edge.get("a_r", 0),
             edge.get("b_q", 0), edge.get("b_r", 0),
         )
-        conn = HexConnection(
+        db.add(HexConnection(
             id=str(uuid.uuid4()),
             workspace_id=workspace_id,
             hex_a_q=aq, hex_a_r=ar,
@@ -211,8 +214,7 @@ async def _apply_template_to_workspace(
             direction=edge.get("direction", "both"),
             auto_created=edge.get("auto_created", False),
             created_by=user_id,
-        )
-        db.add(conn)
+        ))
 
     if "content" in bb_snap:
         bb_result = await db.execute(
@@ -235,32 +237,47 @@ async def apply_internal_deploy_topology(
     topo_snap: dict,
     human_specs: list[dict],
 ) -> None:
-    """Apply filtered topology snapshot (corridors, connections, human hexes) during template deploy."""
+    """Apply filtered topology snapshot (corridors, connections, human hexes) during template deploy.
+
+    Writes directly to node_cards (Runtime v2) instead of legacy corridor_hexes/human_hexes,
+    because _build_hex_map short-circuits when node_cards already has data (agents are
+    already written there by add_agent).
+    """
     import uuid
 
-    from app.models.corridor import CorridorHex, HexConnection, HumanHex, ordered_pair
+    from app.models.corridor import HexConnection, ordered_pair
+    from app.models.node_card import NodeCard
 
     for node in topo_snap.get("nodes", []):
         if node.get("node_type") == "corridor":
-            db.add(CorridorHex(
-                id=str(uuid.uuid4()),
+            db.add(NodeCard(
+                node_type="corridor",
+                node_id=str(uuid.uuid4()),
                 workspace_id=workspace_id,
                 hex_q=node.get("hex_q", 0),
                 hex_r=node.get("hex_r", 0),
-                display_name=node.get("display_name", ""),
-                created_by=user_id,
+                name=node.get("display_name", ""),
+                status="active",
+                tags=[],
+                metadata_={},
             ))
 
     for spec in human_specs:
-        db.add(HumanHex(
-            id=str(uuid.uuid4()),
+        db.add(NodeCard(
+            node_type="human",
+            node_id=spec.get("user_id", user_id),
             workspace_id=workspace_id,
-            user_id=spec.get("user_id", user_id),
             hex_q=spec.get("hex_q", 0),
             hex_r=spec.get("hex_r", 0),
-            display_name=spec.get("display_name"),
-            display_color=spec.get("display_color", "#f59e0b"),
-            created_by=user_id,
+            name=spec.get("display_name", ""),
+            status="active",
+            tags=[],
+            metadata_={
+                "user_id": spec.get("user_id", user_id),
+                "display_color": spec.get("display_color", "#f59e0b"),
+                "channel_type": spec.get("channel_type"),
+                "channel_config": spec.get("channel_config"),
+            },
         ))
 
     await db.flush()

--- a/nodeskclaw-backend/tests/test_blackboard_mentions.py
+++ b/nodeskclaw-backend/tests/test_blackboard_mentions.py
@@ -15,10 +15,17 @@ async def test_notify_mentions_targets_agents_and_guides_reply():
         SimpleNamespace(type="agent", id="inst-002"),
     ]
 
-    with patch(
-        "app.services.collaboration_service.send_system_message_to_agents",
-        new_callable=AsyncMock,
-    ) as mock_send:
+    with (
+        patch(
+            "app.services.collaboration_service.send_system_message_to_agents",
+            new_callable=AsyncMock,
+        ) as mock_send,
+        patch(
+            "app.services.corridor_router.has_any_connections",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
         await _notify_mentions(
             "ws-001",
             mentions,
@@ -45,10 +52,17 @@ async def test_notify_mentions_targets_agents_and_guides_reply():
 async def test_notify_mentions_skips_when_no_agent_targets():
     mentions = [SimpleNamespace(type="human", id="user-001")]
 
-    with patch(
-        "app.services.collaboration_service.send_system_message_to_agents",
-        new_callable=AsyncMock,
-    ) as mock_send:
+    with (
+        patch(
+            "app.services.collaboration_service.send_system_message_to_agents",
+            new_callable=AsyncMock,
+        ) as mock_send,
+        patch(
+            "app.services.corridor_router.has_any_connections",
+            new_callable=AsyncMock,
+            return_value=False,
+        ),
+    ):
         await _notify_mentions(
             "ws-001",
             mentions,


### PR DESCRIPTION
## Summary

- 补充缺失的 `apply_internal_deploy_topology` 方法，修复模板部署在 `setup_topology` 阶段 `AttributeError` 崩溃
- 将过道和人类工位写入 `node_cards`（Runtime v2）替代旧表 `corridor_hexes`/`human_hexes`，修复 `_build_hex_map` 短路逻辑导致过道不显示
- `dev.sh` 后端 uvicorn 加上 `--host 0.0.0.0`，使 Docker 容器可通过 `host.docker.internal` 连接 tunnel

Closes #215

## Test plan

- [x] 模板一键部署后过道正常显示
- [x] Docker 实例 tunnel 连接成功，不再显示 disconnected
- [x] 普通创建办公室 + 模板应用路径同步修复

Made with [Cursor](https://cursor.com)