### PR TITLE
fix(llm): 修复 Docker 部署下 AI 员工容器无法访问 LLM Proxy 的网络隔离问题

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,11 @@ GENEHUB_API_KEY=
 # 若管理 K8s 集群上的 AI 员工，必须改为 K8s Pod 可达的外部地址
 # AGENT_API_BASE_URL=https://your-nodeskclaw-domain.com/api/v1
 
+# LLM_PROXY_URL（大模型代理外部访问地址）：Docker AI 员工容器访问宿主机映射端口使用
+# LLM_PROXY_INTERNAL_URL（大模型代理内网访问地址）：K8s/Compose 主服务内部访问使用
+# LLM_PROXY_URL=http://host.docker.internal:4511
+# LLM_PROXY_INTERNAL_URL=http://llm-proxy:8080
+
 # AI 员工 WebSocket 隧道地址（可选，不设则从 AGENT_API_BASE_URL 推导）
 # 当 WebSocket 需要走不同入口（如独立的 wss:// 域名）时设置
 # TUNNEL_BASE_URL=wss://your-nodeskclaw-domain.com/api/v1/tunnel/connect

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,8 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL:-postgresql+asyncpg://nodeskclaw:nodeskclaw@postgres:5432/nodeskclaw}
       DATABASE_NAME_SUFFIX: ""
-      LLM_PROXY_URL: http://llm-proxy:8080
-      LLM_PROXY_INTERNAL_URL: http://llm-proxy:8080
+      LLM_PROXY_URL: ${LLM_PROXY_URL:-http://host.docker.internal:4511}
+      LLM_PROXY_INTERNAL_URL: ${LLM_PROXY_INTERNAL_URL:-http://llm-proxy:8080}
       NODESKCLAW_EDITION: ce
       DOCKER_DATA_DIR: /nodeskclaw-data
       DOCKER_HOST_DATA_DIR: ${NODESKCLAW_DATA_DIR:-${HOME:-.}/.nodeskclaw/docker-instances}

--- a/nodeskclaw-backend/app/services/llm_config_service.py
+++ b/nodeskclaw-backend/app/services/llm_config_service.py
@@ -10,7 +10,7 @@ import re
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
-from urllib.parse import urlparse as _urlparse
+from urllib.parse import urlparse as _urlparse, urlunparse as _urlunparse
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -135,13 +135,15 @@ def _docker_rewrite_urls(providers: dict) -> dict:
     """Docker 实例使用宿主机可达地址，避免依赖主 compose 网络内的服务名。"""
     proxy_internal_url = (settings.LLM_PROXY_INTERNAL_URL or "").rstrip("/")
     proxy_external_url = _docker_rewrite_url((settings.LLM_PROXY_URL or "").rstrip("/"))
+    if proxy_external_url:
+        proxy_external_url = _docker_rewrite_compose_proxy_url(proxy_external_url)
     for _provider_id, entry in providers.items():
         base_url = entry.get("baseUrl", "")
         if base_url:
             if proxy_internal_url and proxy_external_url and base_url.startswith(proxy_internal_url):
                 entry["baseUrl"] = f"{proxy_external_url}{base_url[len(proxy_internal_url):]}"
             else:
-                entry["baseUrl"] = _docker_rewrite_url(base_url)
+                entry["baseUrl"] = _docker_rewrite_compose_proxy_url(_docker_rewrite_url(base_url))
     return providers
 
 
@@ -728,6 +730,24 @@ async def _deploy_plugin_files(fs: RemoteFS, plugin_source: Path) -> None:
     await _deploy_plugin_files_generic(
         fs, plugin_source, CHANNEL_PLUGIN_REGISTRY["nodeskclaw"],
     )
+
+
+_COMPOSE_ONLY_PROXY_HOSTS = {"llm-proxy", "nodeskclaw-llm-proxy-1"}
+
+
+def _docker_rewrite_compose_proxy_url(url: str) -> str:
+    parsed = _urlparse(url)
+    if parsed.hostname not in _COMPOSE_ONLY_PROXY_HOSTS:
+        return url
+
+    netloc = "host.docker.internal"
+    if parsed.username:
+        netloc = f"{parsed.username}@{netloc}"
+    if parsed.port and parsed.port != 8080:
+        netloc = f"{netloc}:{parsed.port}"
+    else:
+        netloc = f"{netloc}:4511"
+    return _urlunparse(parsed._replace(netloc=netloc))
 
 
 def _docker_rewrite_url(url: str) -> str:

--- a/nodeskclaw-backend/tests/test_codex_config_defaults.py
+++ b/nodeskclaw-backend/tests/test_codex_config_defaults.py
@@ -56,3 +56,19 @@ def test_docker_rewrite_urls_uses_external_proxy_url(monkeypatch):
     rewritten = _docker_rewrite_urls(providers)
 
     assert rewritten["codex"]["baseUrl"] == "http://host.docker.internal:18080/codex/v1"
+
+
+def test_docker_rewrite_urls_rewrites_compose_proxy_service(monkeypatch):
+    monkeypatch.setattr(settings, "LLM_PROXY_INTERNAL_URL", "http://llm-proxy:8080")
+    monkeypatch.setattr(settings, "LLM_PROXY_URL", "http://llm-proxy:8080")
+
+    providers = {
+        "glm": {
+            "baseUrl": "http://llm-proxy:8080/glm/v1",
+            "apiKey": "proxy-token",
+        }
+    }
+
+    rewritten = _docker_rewrite_urls(providers)
+
+    assert rewritten["glm"]["baseUrl"] == "http://host.docker.internal:4511/glm/v1"


### PR DESCRIPTION
Docker 实例运行在隔离网络，无法解析 Compose 内部服务名（如 llm-proxy:8080）。 将 LLM_PROXY_URL 默认值改为 host.docker.internal:4511，并新增 _docker_rewrite_compose_proxy_url() 确保遗留配置也被正确重写。

## Summary

<!-- Brief description of the changes -->

## Changes

- 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Other (describe):

## Checklist

- [ ] Code follows the project coding style
- [ ] Self-reviewed the code
- [ ] Added necessary tests (if applicable)
- [ ] Updated documentation (if applicable)
- [ ] No breaking changes (or documented in summary)
