### PR TITLE
refactor(runtime): 建立运行时能力声明基础

### DIFF
--- a/docs/runtime-onboarding.md
+++ b/docs/runtime-onboarding.md
@@ -1,0 +1,110 @@
+# Runtime Onboarding Checklist（运行时接入检查清单）
+
+本清单用于接入新的 AI employee runtime（AI 员工运行时）。目标是让每个 runtime（运行时）在注册、能力声明、配置、备份和前端展示上都有明确契约，避免继续继承 OpenClaw（默认员工引擎）的隐式语义。
+
+## 1. RuntimeSpec（运行时规格）注册
+
+新增 runtime（运行时）时，必须显式填写以下字段，不允许依赖默认值：
+
+| 字段 | 说明 |
+| --- | --- |
+| `runtime_id` | runtime（运行时）唯一标识符 |
+| `config_rel_path` | 主配置文件相对路径 |
+| `config_format` | 配置格式，例如 `json`（JSON 配置）或 `yaml`（YAML 配置） |
+| `channels_section_key` | channel（渠道）配置所在字段名 |
+| `field_naming` | 配置字段命名风格，例如 `camelCase`（小驼峰） |
+| `data_dir_container_path` | 容器内数据根目录 |
+| `skills_dir_rel` | skill（技能）目录相对路径 |
+| `scripts_dir_rel` | script（脚本）目录相对路径 |
+| `gateway_port` | gateway（网关）端口 |
+| `backup_dirs` | backup（备份）必须包含的目录 |
+| `capabilities` | product capabilities（产品能力矩阵） |
+
+`RuntimeSpec`（运行时规格）注册时会校验关键字段。漏填关键字段应该在启动或测试阶段暴露，而不是静默继承 OpenClaw（默认员工引擎）路径。
+
+## 2. Product Capabilities（产品能力矩阵）
+
+每个 runtime（运行时）必须完整声明以下 capability（能力）：
+
+| Capability（能力） | 说明 |
+| --- | --- |
+| `genes` | 是否支持 Gene（基因）安装和管理入口 |
+| `evolution_log` | 是否展示 evolution log（进化日志） |
+| `llm_config` | 是否支持 LLM config（模型配置） |
+| `channel_config` | 是否支持 channel config（渠道配置） |
+| `channel_plugin_discovery` | 是否支持 channel plugin discovery（渠道插件发现） |
+| `repo_channel_sync` | 是否支持 repo channel sync（仓库渠道同步） |
+| `npm_channel_install` | 是否支持 npm channel install（npm 渠道安装） |
+| `upload_channel_plugin` | 是否支持 upload channel plugin（上传渠道插件） |
+| `gateway` | 是否提供 gateway（网关） |
+| `health_endpoint` | 是否提供 health endpoint（健康检查端点） |
+| `config_endpoint` | 是否提供 config endpoint（配置端点） |
+| `web_ui` | 是否提供 Web UI（网页界面） |
+| `backup` | 是否支持 backup（备份） |
+| `runtime_config_patch` | 是否支持 runtime config patch（运行时配置补丁） |
+| `tool_allow` | 是否支持 tool allowlist（工具允许列表） |
+
+声明为 `true` 的 capability（能力）必须有真实实现。声明为 `false` 的 capability（能力）必须通过 `UnsupportedCapabilityError`（不支持能力错误）或 warnings（警告）明确表达，不允许静默忽略。
+
+## 3. Adapter（适配器）要求
+
+`GeneInstallAdapter`（基因安装适配器）需要明确实现或拒绝以下能力：
+
+| 方法 | 要求 |
+| --- | --- |
+| `deploy_skill` | 支持时写入 runtime-native skill（运行时原生技能）目录 |
+| `allow_tools` | 不支持 `tool_allow` 时必须返回 warnings（警告）或抛 `UnsupportedCapabilityError` |
+| `deploy_scripts` | 支持时写入 runtime-native script（运行时原生脚本）目录 |
+| `apply_config` | 不支持 `runtime_config_patch` 时必须返回 warnings（警告）或抛 `UnsupportedCapabilityError` |
+| `invalidate_cache` | 支持时清理 runtime（运行时）缓存 |
+| `remove_skill` | 支持时删除 runtime-native skill（运行时原生技能） |
+| `post_remove_cleanup` | 支持时执行删除后的清理 |
+
+`RuntimeConfigAdapter`（运行时配置适配器）需要负责配置读取、写入、channel（渠道）提取和 channel（渠道）合并。
+
+Channel plugin（渠道插件）能力第一阶段通过 capability gate（能力门禁）表达。runtime（运行时）不支持时，相关操作必须返回 `UNSUPPORTED_CAPABILITY`（不支持能力）。
+
+## 4. API（接口）与 Frontend（前端）
+
+`/engines` API（引擎列表接口）必须返回完整 `capabilities`（能力矩阵）。
+
+Frontend（前端）消费规则：
+
+1. 优先使用 `/engines[].capabilities`（后端能力声明）。
+2. 旧后端或接口异常时，fallback（兜底）到最小安全能力集。
+3. 未知 runtime（运行时）不能 fallback（兜底）到 OpenClaw（默认员工引擎）。
+4. UI（用户界面）入口显隐必须由 capability（能力）驱动。
+
+## 5. Gene Manifest（基因清单）兼容性
+
+新增 runtime（运行时）时，需要明确支持哪些 Gene manifest（基因清单）字段：
+
+- `runtime_config`（运行时配置）
+- `openclaw_config`（OpenClaw 专用配置）
+- `tool_allow`（工具允许列表）
+- `scripts`（脚本）
+- `skill`（技能）
+
+对于不支持的字段，安装结果必须返回 warnings（警告）或 structured unsupported（结构化不支持信息），说明哪些字段没有生效。
+
+## 6. Test（测试）要求
+
+每个新增 runtime（运行时）至少补充以下测试：
+
+1. `RuntimeSpec`（运行时规格）关键字段断言。
+2. capability matrix（能力矩阵）断言。
+3. `/engines` API（引擎列表接口）响应断言。
+4. unsupported capability（不支持能力）行为断言。
+5. OpenClaw（默认员工引擎）回归测试，确保新增 runtime（运行时）不改变既有行为。
+
+## 7. PR（合并请求）要求
+
+接入新 runtime（运行时）的 PR（合并请求）需要在描述里逐条回应本清单：
+
+- RuntimeSpec（运行时规格）字段是否完整。
+- capabilities（能力矩阵）是否完整。
+- unsupported（不支持能力）是否可见。
+- `/engines` API（引擎列表接口）是否返回能力。
+- Frontend（前端）是否正确消费能力。
+- 测试是否覆盖 capability（能力）和 OpenClaw（默认员工引擎）回归。
+

--- a/nodeskclaw-backend/app/api/engines.py
+++ b/nodeskclaw-backend/app/api/engines.py
@@ -25,6 +25,21 @@ async def list_engines(_user: User = Depends(get_current_user)):
             "image_registry_key": spec.image_registry_key,
             "default_registry_url": DEFAULT_REGISTRY_CONFIGS.get(spec.image_registry_key, ""),
             "available": spec.available,
+            "gateway_port": spec.gateway_port,
+            "health_probe_path": spec.health_probe_path,
+            "readiness_probe_path": spec.readiness_probe_path,
+            "config_rel_path": spec.config_rel_path,
+            "config_format": spec.config_format,
+            "channels_section_key": spec.channels_section_key,
+            "field_naming": spec.field_naming,
+            "supports_channel_plugins": spec.supports_channel_plugins,
+            "data_dir_container_path": spec.data_dir_container_path,
+            "skills_dir_rel": spec.skills_dir_rel,
+            "scripts_dir_rel": spec.scripts_dir_rel,
+            "has_web_ui": spec.has_web_ui,
+            "backup_dirs": list(spec.backup_dirs),
+            "backup_exclude_patterns": list(spec.backup_exclude_patterns),
+            "capabilities": spec.capability_map(),
         })
     engines.sort(key=lambda r: r["order"])
     return ApiResponse(data=engines)

--- a/nodeskclaw-backend/app/core/exceptions.py
+++ b/nodeskclaw-backend/app/core/exceptions.py
@@ -20,12 +20,14 @@ class AppException(Exception):
         message_key: str | None = None,
         error_code: int | None = None,
         message_params: dict[str, str] | None = None,
+        details: dict[str, Any] | None = None,
     ):
         self.code = code
         self.error_code = error_code if error_code is not None else code
         self.message = message
         self.message_key = message_key
         self.message_params = message_params
+        self.details = details
         self.status_code = status_code
 
 
@@ -73,6 +75,37 @@ class K8sError(AppException):
 class RegistryError(AppException):
     def __init__(self, message: str = "镜像仓库请求失败", message_key: str = "errors.registry.request_failed"):
         super().__init__(code=50220, message=message, status_code=502, message_key=message_key)
+
+
+class UnsupportedCapabilityError(AppException):
+    def __init__(
+        self,
+        runtime_id: str,
+        capability: str,
+        operation: str | None = None,
+        message: str | None = None,
+    ):
+        details = {
+            "code": "UNSUPPORTED_CAPABILITY",
+            "runtime_id": runtime_id,
+            "capability": capability,
+        }
+        params = {
+            "runtime_id": runtime_id,
+            "capability": capability,
+        }
+        if operation:
+            details["operation"] = operation
+            params["operation"] = operation
+
+        super().__init__(
+            code=40080,
+            message=message or f"当前运行时不支持 {capability} 能力",
+            status_code=400,
+            message_key="errors.runtime.unsupported_capability",
+            message_params=params,
+            details=details,
+        )
 
 
 HTTP_STATUS_DEFAULT_CODES: dict[int, int] = {
@@ -125,6 +158,8 @@ def register_exception_handlers(app: FastAPI) -> None:
         }
         if exc.message_params:
             body["message_params"] = exc.message_params
+        if exc.details:
+            body["details"] = exc.details
         return JSONResponse(status_code=exc.status_code, content=body)
 
     @app.exception_handler(HTTPException)

--- a/nodeskclaw-backend/app/services/runtime/registries/runtime_registry.py
+++ b/nodeskclaw-backend/app/services/runtime/registries/runtime_registry.py
@@ -3,10 +3,34 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RuntimeProductCapabilities:
+    """Product-facing runtime capabilities consumed by APIs and frontend UI."""
+
+    genes: bool
+    evolution_log: bool
+    llm_config: bool
+    channel_config: bool
+    channel_plugin_discovery: bool
+    repo_channel_sync: bool
+    npm_channel_install: bool
+    upload_channel_plugin: bool
+    gateway: bool
+    health_endpoint: bool
+    config_endpoint: bool
+    web_ui: bool
+    backup: bool
+    runtime_config_patch: bool
+    tool_allow: bool
+
+    def to_dict(self) -> dict[str, bool]:
+        return asdict(self)
 
 
 @dataclass(frozen=True)
@@ -21,21 +45,22 @@ class RuntimeSpec:
     display_description: str = ""
     display_tags: tuple[str, ...] = ()
     display_powered_by: str = ""
-    gateway_port: int = 18789
-    health_probe_path: str | None = "/healthz"
+    capabilities: RuntimeProductCapabilities | None = None
+    gateway_port: int | None = None
+    health_probe_path: str | None = None
     readiness_probe_path: str | None = None
     order: int = 0
     image_registry_key: str = "image_registry"
-    config_rel_path: str = ".openclaw/openclaw.json"
-    config_format: str = "json"
-    channels_section_key: str = "channels"
-    field_naming: str = "camelCase"
-    supports_channel_plugins: bool = True
-    data_dir_container_path: str = "/root/.openclaw"
-    skills_dir_rel: str = ".openclaw/skills"
-    scripts_dir_rel: str = ".deskclaw/tools"
-    has_web_ui: bool = True
-    has_init_script: bool = True
+    config_rel_path: str = ""
+    config_format: str = ""
+    channels_section_key: str = ""
+    field_naming: str = ""
+    supports_channel_plugins: bool = False
+    data_dir_container_path: str = ""
+    skills_dir_rel: str = ""
+    scripts_dir_rel: str = ""
+    has_web_ui: bool = False
+    has_init_script: bool = False
     available: bool = True
     docker_command: tuple[str, ...] | None = None
     docker_seed_template_rel: str | None = None
@@ -44,12 +69,18 @@ class RuntimeSpec:
         "node_modules", "dist", "__pycache__", ".git", "cache", "*.pyc",
     )
 
+    def capability_map(self) -> dict[str, bool]:
+        if self.capabilities is None:
+            raise RuntimeError(f"Runtime {self.runtime_id} missing product capabilities")
+        return self.capabilities.to_dict()
+
 
 class RuntimeRegistry:
     def __init__(self) -> None:
         self._runtimes: dict[str, RuntimeSpec] = {}
 
     def register(self, spec: RuntimeSpec) -> None:
+        _validate_runtime_spec(spec)
         self._runtimes[spec.runtime_id] = spec
         logger.debug("Registered runtime: %s", spec.runtime_id)
 
@@ -61,6 +92,29 @@ class RuntimeRegistry:
 
 
 RUNTIME_REGISTRY = RuntimeRegistry()
+
+
+def _validate_runtime_spec(spec: RuntimeSpec) -> None:
+    required_string_fields = (
+        "config_rel_path",
+        "config_format",
+        "channels_section_key",
+        "field_naming",
+        "data_dir_container_path",
+        "skills_dir_rel",
+        "scripts_dir_rel",
+    )
+    missing = [name for name in required_string_fields if not getattr(spec, name)]
+    if spec.gateway_port is None:
+        missing.append("gateway_port")
+    if spec.capabilities is None:
+        missing.append("capabilities")
+    if not spec.backup_dirs:
+        missing.append("backup_dirs")
+    if missing:
+        raise RuntimeError(
+            f"Runtime {spec.runtime_id} missing required RuntimeSpec fields: {', '.join(missing)}"
+        )
 
 
 def _register_builtins() -> None:
@@ -87,8 +141,37 @@ def _register_builtins() -> None:
         display_description="支持工具调用、基因系统、多技能管理",
         display_tags=("默认",),
         display_powered_by="OpenClaw",
+        capabilities=RuntimeProductCapabilities(
+            genes=True,
+            evolution_log=True,
+            llm_config=True,
+            channel_config=True,
+            channel_plugin_discovery=True,
+            repo_channel_sync=True,
+            npm_channel_install=True,
+            upload_channel_plugin=True,
+            gateway=True,
+            health_endpoint=True,
+            config_endpoint=True,
+            web_ui=True,
+            backup=True,
+            runtime_config_patch=True,
+            tool_allow=True,
+        ),
+        gateway_port=18789,
+        health_probe_path="/healthz",
         readiness_probe_path="/readyz",
         order=0,
+        config_rel_path=".openclaw/openclaw.json",
+        config_format="json",
+        channels_section_key="channels",
+        field_naming="camelCase",
+        supports_channel_plugins=True,
+        data_dir_container_path="/root/.openclaw",
+        skills_dir_rel=".openclaw/skills",
+        scripts_dir_rel=".deskclaw/tools",
+        has_web_ui=True,
+        has_init_script=True,
         docker_seed_template_rel="openclaw.json.template",
         backup_dirs=(".openclaw", ".deskclaw/tools"),
     ))
@@ -102,6 +185,23 @@ def _register_builtins() -> None:
         display_description="超轻量，快速部署，适合简单对话场景",
         display_tags=(),
         display_powered_by="Nanobot",
+        capabilities=RuntimeProductCapabilities(
+            genes=False,
+            evolution_log=True,
+            llm_config=False,
+            channel_config=True,
+            channel_plugin_discovery=False,
+            repo_channel_sync=False,
+            npm_channel_install=False,
+            upload_channel_plugin=False,
+            gateway=True,
+            health_endpoint=False,
+            config_endpoint=True,
+            web_ui=False,
+            backup=True,
+            runtime_config_patch=False,
+            tool_allow=False,
+        ),
         gateway_port=18790,
         health_probe_path=None,
         order=2,
@@ -113,6 +213,7 @@ def _register_builtins() -> None:
         supports_channel_plugins=False,
         data_dir_container_path="/root/.nanobot",
         skills_dir_rel=".deskclaw/skills",
+        scripts_dir_rel=".deskclaw/tools",
         has_web_ui=False,
         has_init_script=False,
         available=False,
@@ -128,6 +229,23 @@ def _register_builtins() -> None:
         display_description="面向长期运行 Agent 的通用执行引擎",
         display_tags=("实验",),
         display_powered_by="Hermes Agent",
+        capabilities=RuntimeProductCapabilities(
+            genes=True,
+            evolution_log=True,
+            llm_config=True,
+            channel_config=True,
+            channel_plugin_discovery=False,
+            repo_channel_sync=False,
+            npm_channel_install=False,
+            upload_channel_plugin=False,
+            gateway=True,
+            health_endpoint=True,
+            config_endpoint=True,
+            web_ui=False,
+            backup=True,
+            runtime_config_patch=False,
+            tool_allow=False,
+        ),
         gateway_port=8642,
         health_probe_path="/health",
         order=1,

--- a/nodeskclaw-backend/tests/test_runtime_capability_errors.py
+++ b/nodeskclaw-backend/tests/test_runtime_capability_errors.py
@@ -1,0 +1,24 @@
+from app.core.exceptions import UnsupportedCapabilityError
+
+
+def test_unsupported_capability_error_exposes_structured_details():
+    error = UnsupportedCapabilityError(
+        runtime_id="hermes",
+        capability="tool_allow",
+        operation="gene.allow_tools",
+    )
+
+    assert error.code == 40080
+    assert error.status_code == 400
+    assert error.message_key == "errors.runtime.unsupported_capability"
+    assert error.message_params == {
+        "runtime_id": "hermes",
+        "capability": "tool_allow",
+        "operation": "gene.allow_tools",
+    }
+    assert error.details == {
+        "code": "UNSUPPORTED_CAPABILITY",
+        "runtime_id": "hermes",
+        "capability": "tool_allow",
+        "operation": "gene.allow_tools",
+    }

--- a/nodeskclaw-backend/tests/test_runtime_registry_display.py
+++ b/nodeskclaw-backend/tests/test_runtime_registry_display.py
@@ -1,4 +1,8 @@
+import pytest
+
+from app.api.engines import list_engines
 from app.services.runtime.registries.runtime_registry import RUNTIME_REGISTRY
+from app.services.runtime.registries.runtime_registry import RuntimeProductCapabilities, RuntimeRegistry, RuntimeSpec
 
 
 def test_runtime_registry_display_order_and_names():
@@ -9,3 +13,69 @@ def test_runtime_registry_display_order_and_names():
         ("hermes", "自进化员工引擎", 1),
         ("nanobot", "轻量工作引擎", 2),
     ]
+
+
+def test_runtime_specs_have_complete_product_capabilities():
+    expected_keys = set(RuntimeProductCapabilities.__dataclass_fields__.keys())
+
+    for spec in RUNTIME_REGISTRY.all_runtimes():
+        capabilities = spec.capability_map()
+        assert set(capabilities.keys()) == expected_keys
+        assert spec.gateway_port is not None
+        assert spec.config_rel_path
+        assert spec.config_format
+        assert spec.channels_section_key
+        assert spec.field_naming
+        assert spec.data_dir_container_path
+        assert spec.skills_dir_rel
+        assert spec.scripts_dir_rel
+        assert spec.backup_dirs
+
+
+def test_builtin_runtime_capability_matrix_matches_first_stage_contract():
+    openclaw = RUNTIME_REGISTRY.get("openclaw")
+    hermes = RUNTIME_REGISTRY.get("hermes")
+    nanobot = RUNTIME_REGISTRY.get("nanobot")
+
+    assert openclaw is not None
+    assert hermes is not None
+    assert nanobot is not None
+
+    assert openclaw.capability_map()["tool_allow"] is True
+    assert openclaw.capability_map()["runtime_config_patch"] is True
+    assert openclaw.capability_map()["repo_channel_sync"] is True
+    assert openclaw.capability_map()["web_ui"] is True
+
+    assert hermes.capability_map()["genes"] is True
+    assert hermes.capability_map()["evolution_log"] is True
+    assert hermes.capability_map()["tool_allow"] is False
+    assert hermes.capability_map()["runtime_config_patch"] is False
+    assert hermes.capability_map()["repo_channel_sync"] is False
+    assert hermes.capability_map()["web_ui"] is False
+
+    assert nanobot.capability_map()["genes"] is False
+    assert nanobot.capability_map()["evolution_log"] is True
+    assert nanobot.capability_map()["tool_allow"] is False
+
+
+def test_runtime_registry_rejects_specs_missing_required_product_metadata():
+    registry = RuntimeRegistry()
+
+    with pytest.raises(RuntimeError, match="capabilities"):
+        registry.register(RuntimeSpec(runtime_id="custom"))
+
+
+@pytest.mark.asyncio
+async def test_engine_listing_returns_runtime_capabilities():
+    response = await list_engines(_user=object())
+    engines = {item["runtime_id"]: item for item in response.data}
+
+    assert engines["openclaw"]["capabilities"]["tool_allow"] is True
+    assert engines["openclaw"]["config_rel_path"] == ".openclaw/openclaw.json"
+    assert engines["openclaw"]["backup_dirs"] == [".openclaw", ".deskclaw/tools"]
+
+    assert engines["hermes"]["capabilities"]["evolution_log"] is True
+    assert engines["hermes"]["capabilities"]["tool_allow"] is False
+    assert engines["hermes"]["config_rel_path"] == ".hermes/config.yaml"
+
+    assert engines["nanobot"]["capabilities"]["genes"] is False


### PR DESCRIPTION
## Summary

- Add product-facing runtime capabilities to RuntimeSpec and expose them from /engines.
- Remove implicit OpenClaw defaults from built-in runtime registration by making OpenClaw, Hermes, and Nanobot declare paths and capability matrices explicitly.
- Add UnsupportedCapabilityError as the shared backend error contract foundation.
- Add runtime onboarding checklist documentation and backend tests for capability matrices and /engines output.

## Discussion

- Follows the first PR split from https://github.com/NoDeskAI/nodeskclaw/discussions/254

## Tests

- DATABASE_URL=postgresql+asyncpg://nodeskclaw:nodeskclaw@localhost:5432/nodeskclaw_test JWT_SECRET=test-jwt-secret ENCRYPTION_KEY=test-encryption-key-32bytes uv run pytest tests/test_runtime_registry_display.py tests/test_runtime_capability_errors.py tests/test_hermes_gene_install_adapter.py tests/test_docker_provider_paths.py
- uv run ruff check app/services/runtime/registries/runtime_registry.py app/api/engines.py app/core/exceptions.py tests/test_runtime_registry_display.py tests/test_runtime_capability_errors.py