### PR TITLE
fix(llm): 修复员工代理内网地址解析

### DIFF
--- a/nodeskclaw-backend/app/core/config.py
+++ b/nodeskclaw-backend/app/core/config.py
@@ -21,6 +21,21 @@ def _detect_platform_namespace() -> str:
         return "nodeskclaw-system"
 
 
+def _qualify_k8s_service_url(url: str, service_name: str, namespace: str) -> str:
+    normalized = url.rstrip("/")
+    parsed = urlsplit(normalized)
+    if parsed.hostname != service_name:
+        return normalized
+
+    namespace = namespace.strip()
+    if not namespace:
+        return normalized
+
+    host = f"{service_name}.{namespace}.svc.cluster.local"
+    netloc = f"{host}:{parsed.port}" if parsed.port else host
+    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)).rstrip("/")
+
+
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
@@ -109,6 +124,16 @@ class Settings(BaseSettings):
     NODESKCLAW_HOST: str = ""  # 外部可达域名，如 https://nodeskclaw.example.com（废弃，保留兼容）
     LLM_PROXY_URL: str = ""  # 独立 LLM Proxy 服务外部地址，如 https://llm-proxy.example.com
     LLM_PROXY_INTERNAL_URL: str = ""  # K8s 集群内网地址，用于 openclaw.json 中的 baseUrl（绕过 ALB）
+
+    @model_validator(mode="after")
+    def _qualify_llm_proxy_internal_url(self) -> "Settings":
+        if self.LLM_PROXY_INTERNAL_URL:
+            self.LLM_PROXY_INTERNAL_URL = _qualify_k8s_service_url(
+                self.LLM_PROXY_INTERNAL_URL,
+                "nodeskclaw-llm-proxy",
+                self.PLATFORM_NAMESPACE,
+            )
+        return self
 
     # ── Agent API（AI 员工 Pod 回调后端的内网地址）────────
     AGENT_API_BASE_URL: str = "http://localhost:4510/api/v1"

--- a/nodeskclaw-backend/tests/test_settings.py
+++ b/nodeskclaw-backend/tests/test_settings.py
@@ -1,0 +1,26 @@
+from app.core.config import Settings
+
+
+def test_settings_qualifies_k8s_llm_proxy_service_url() -> None:
+    settings = Settings(
+        DEBUG=True,
+        DATABASE_URL="postgresql+asyncpg://user:pass@localhost:5432/nodeskclaw_test",
+        LLM_PROXY_INTERNAL_URL="http://nodeskclaw-llm-proxy:80",
+        PLATFORM_NAMESPACE="nodeskclaw-system",
+    )
+
+    assert (
+        settings.LLM_PROXY_INTERNAL_URL
+        == "http://nodeskclaw-llm-proxy.nodeskclaw-system.svc.cluster.local:80"
+    )
+
+
+def test_settings_keeps_non_k8s_llm_proxy_service_url() -> None:
+    settings = Settings(
+        DEBUG=True,
+        DATABASE_URL="postgresql+asyncpg://user:pass@localhost:5432/nodeskclaw_test",
+        LLM_PROXY_INTERNAL_URL="http://llm-proxy:8080",
+        PLATFORM_NAMESPACE="nodeskclaw-system",
+    )
+
+    assert settings.LLM_PROXY_INTERNAL_URL == "http://llm-proxy:8080"


### PR DESCRIPTION
## 背景

K8s 部署中，AI 员工运行在独立 namespace，`nodeskclaw-llm-proxy` 短服务名只能在 `nodeskclaw-system` namespace 内解析。后端将该短地址写入运行时配置后，员工 Pod 无法解析 LLM Proxy，模型调用会失败。

## 变更

- 在 Settings 初始化时规范化 `LLM_PROXY_INTERNAL_URL`。
- 当内部代理地址主机名为 `nodeskclaw-llm-proxy` 时，自动补全为 `nodeskclaw-llm-proxy.<PLATFORM_NAMESPACE>.svc.cluster.local`。
- 保持 Docker Compose 场景的 `llm-proxy` 地址不变。
- 增加 K8s 和非 K8s 地址场景测试。

## 验证

- `DEBUG=true DATABASE_URL=postgresql+asyncpg://nodeskclaw:nodeskclaw@localhost:5432/nodeskclaw_test /Users/shaynemacmini/Library/Python/3.9/bin/uv run pytest tests/test_settings.py tests/test_llm_config_service.py tests/test_codex_config_defaults.py`
- `DEBUG=true DATABASE_URL=postgresql+asyncpg://nodeskclaw:nodeskclaw@localhost:5432/nodeskclaw_test /Users/shaynemacmini/Library/Python/3.9/bin/uv run ruff check app/core/config.py tests/test_settings.py`
